### PR TITLE
fix(userscript): stabilize Maybank refs and background sync on load

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Monorepo for the UOB credit-card userscript and the optional sync backend. Every
 - Raw transactions remain local to your browser.
 - Synced encrypted payload contains card settings + monthly totals only.
 - `Sync Now` updates the active card key while preserving other remote card keys.
-- When sync is enabled, the userscript also attempts a background sync for the active card during supported bank-page load (if unlocked or remembered unlock is available).
+- When sync is enabled, the userscript attempts background sync for the active card after table-driven local state changes on supported bank pages (if unlocked or remembered unlock is available).
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Monorepo for the UOB credit-card userscript and the optional sync backend. Every
 - Raw transactions remain local to your browser.
 - Synced encrypted payload contains card settings + monthly totals only.
 - `Sync Now` updates the active card key while preserving other remote card keys.
+- When sync is enabled, the userscript also attempts a background sync for the active card during supported bank-page load (if unlocked or remembered unlock is available).
 
 ## Documentation
 

--- a/TECHNICAL.md
+++ b/TECHNICAL.md
@@ -34,7 +34,7 @@
 ## Sync behavior notes
 
 - `Sync Now` performs encrypted settings synchronization through `GET /sync/data` and `PUT /sync/data`.
-- On supported bank-page load, if sync is enabled, the userscript attempts background sync for the active card without requiring the Subcap Tools overlay to be opened.
+- On supported bank pages, if sync is enabled, the userscript attempts background sync for the active card only after table-driven updates change local card sync state, without requiring the Subcap Tools overlay to be opened.
 - Sync payload remains card-keyed under a `cards` envelope (`{ cards: { [cardName]: ... } }`), so adding new cards (e.g., `XL Rewards Card`) is backward-compatible and requires no backend schema/API changes.
 - `Sync Now` updates only the active card key from the current page and preserves other remote card keys.
 - Each synced card payload includes `selectedCategories`, `defaultCategory`, `merchantMap`, and `monthlyTotals`; it excludes raw `transactions`.

--- a/TECHNICAL.md
+++ b/TECHNICAL.md
@@ -34,6 +34,7 @@
 ## Sync behavior notes
 
 - `Sync Now` performs encrypted settings synchronization through `GET /sync/data` and `PUT /sync/data`.
+- On supported bank-page load, if sync is enabled, the userscript attempts background sync for the active card without requiring the Subcap Tools overlay to be opened.
 - Sync payload remains card-keyed under a `cards` envelope (`{ cards: { [cardName]: ... } }`), so adding new cards (e.g., `XL Rewards Card`) is backward-compatible and requires no backend schema/API changes.
 - `Sync Now` updates only the active card key from the current page and preserves other remote card keys.
 - Each synced card payload includes `selectedCategories`, `defaultCategory`, `merchantMap`, and `monthlyTotals`; it excludes raw `transactions`.

--- a/apps/userscript/__tests__/card-context.test.js
+++ b/apps/userscript/__tests__/card-context.test.js
@@ -56,6 +56,20 @@ describe('card context helpers', () => {
     assert.equal(match, null);
   });
 
+  it('findActiveCardName does not fallback when strict primary xpath is non-matching', () => {
+    const profile = {
+      cardNameXPaths: ['//primary', '//fallback'],
+      strictPrimaryCardNameXPath: true
+    };
+    const nodes = {
+      '//primary': makeElement('Maybank Family Card'),
+      '//fallback': makeElement('XL Rewards Card')
+    };
+    globalThis.document.evaluate = (xpath) => ({ singleNodeValue: nodes[xpath] || null });
+    const match = exports.findActiveCardName(profile, { requireVisible: false });
+    assert.equal(match, null);
+  });
+
   it('matchesProfile checks host and path', () => {
     globalThis.window = {
       location: { hostname: 'pib.uob.com.sg', href: 'https://pib.uob.com.sg/PIBCust/2FA/processSubmit.do', pathname: '/PIBCust/2FA/processSubmit.do' }

--- a/apps/userscript/__tests__/main-flow-extended.test.js
+++ b/apps/userscript/__tests__/main-flow-extended.test.js
@@ -230,4 +230,75 @@ describe('main flow extended', () => {
     assert.notEqual(button, null, 'cc-subcap-btn should be created after Maybank main flow');
     timers.unbindFromWindow();
   });
+
+  it('skips initial background sync when table parse does not change fingerprint', async () => {
+    const doc = makeDocument();
+    globalThis.document = doc;
+    globalThis.Element = class {};
+    globalThis.MutationObserver = class { observe() {} disconnect() {} };
+    globalThis.window = {
+      location: {
+        origin: 'https://cib.maybank2u.com.sg',
+        hostname: 'cib.maybank2u.com.sg',
+        href: 'https://cib.maybank2u.com.sg/m2u/accounts/cards',
+        pathname: '/m2u/accounts/cards'
+      },
+      localStorage: { getItem: () => null, setItem: () => {}, removeItem: () => {} },
+      setTimeout: () => 0,
+      clearTimeout: () => {},
+      setInterval: () => {},
+      clearInterval: () => {},
+      getComputedStyle: () => ({ display: 'block', visibility: 'visible', opacity: '1' })
+    };
+    const timers = createFakeTimers();
+    timers.bindToWindow(globalThis.window);
+    globalThis.localStorage = globalThis.window.localStorage;
+    globalThis.getComputedStyle = globalThis.window.getComputedStyle;
+
+    const cardNode = new globalThis.Element();
+    cardNode.textContent = 'XL Rewards Card';
+    cardNode.innerText = 'XL Rewards Card';
+    cardNode.isConnected = true;
+    cardNode.getBoundingClientRect = () => ({ width: 10, height: 10 });
+    const tbodyNode = new globalThis.Element();
+    tbodyNode.querySelectorAll = () => [];
+    doc.evaluate = (xpath) => {
+      const lower = String(xpath).toLowerCase();
+      if (lower.includes('xl rewards card')) {
+        return { singleNodeValue: cardNode };
+      }
+      if (lower.includes('tbody')) {
+        return { singleNodeValue: tbodyNode };
+      }
+      return { singleNodeValue: null };
+    };
+
+    const originalMethods = {
+      isEnabled: exports.SyncManager.prototype.isEnabled,
+      isUnlocked: exports.SyncManager.prototype.isUnlocked,
+      tryUnlockFromRememberedCache: exports.SyncManager.prototype.tryUnlockFromRememberedCache,
+      sync: exports.SyncManager.prototype.sync
+    };
+    let syncCallCount = 0;
+    exports.SyncManager.prototype.isEnabled = () => true;
+    exports.SyncManager.prototype.isUnlocked = () => true;
+    exports.SyncManager.prototype.tryUnlockFromRememberedCache = async () => true;
+    exports.SyncManager.prototype.sync = async () => {
+      syncCallCount += 1;
+      return { success: true };
+    };
+
+    try {
+      const mainPromise = exports.main();
+      await waitForAsyncTimers(timers);
+      await mainPromise;
+      assert.equal(syncCallCount, 0, 'should not sync when pre/post fingerprint is unchanged');
+    } finally {
+      exports.SyncManager.prototype.isEnabled = originalMethods.isEnabled;
+      exports.SyncManager.prototype.isUnlocked = originalMethods.isUnlocked;
+      exports.SyncManager.prototype.tryUnlockFromRememberedCache = originalMethods.tryUnlockFromRememberedCache;
+      exports.SyncManager.prototype.sync = originalMethods.sync;
+      timers.unbindFromWindow();
+    }
+  });
 });

--- a/apps/userscript/__tests__/storage-and-transactions-extended.test.js
+++ b/apps/userscript/__tests__/storage-and-transactions-extended.test.js
@@ -75,6 +75,56 @@ describe('storage + transactions (extended)', () => {
     assert.equal(totals['2024-01'].totals.Travel, 2);
   });
 
+  it('updateStoredTransactions migrates legacy Maybank synthetic keys to #1', () => {
+    const recentIso = exports.toISODate(new Date());
+    const legacyRef = `MB:${recentIso}:10.00:abcd1234`;
+    const settings = {
+      cards: {
+        'XL Rewards Card': {
+          selectedCategories: [],
+          defaultCategory: 'Others',
+          merchantMap: {},
+          transactions: {
+            [legacyRef]: {
+              ref_no: legacyRef,
+              posting_date_iso: recentIso,
+              posting_date: recentIso,
+              transaction_date: '',
+              merchant_detail: 'GRAB SGP',
+              amount_text: '-SGD 10.00',
+              amount_value: 10,
+              category: 'Local'
+            }
+          }
+        }
+      }
+    };
+
+    const incoming = [
+      {
+        ref_no: `${legacyRef}#1`,
+        posting_date_iso: recentIso,
+        posting_date: recentIso,
+        transaction_date: '',
+        merchant_detail: 'GRAB SGP',
+        amount_text: '-SGD 10.00',
+        amount_value: 10,
+        category: 'Local'
+      }
+    ];
+
+    exports.updateStoredTransactions(
+      settings,
+      'XL Rewards Card',
+      exports.CARD_CONFIGS['XL Rewards Card'],
+      incoming
+    );
+
+    const stored = settings.cards['XL Rewards Card'].transactions;
+    assert.equal(Object.keys(stored).length, 1);
+    assert.notEqual(stored[`${legacyRef}#1`], undefined);
+  });
+
   it('buildFallbackData returns empty diagnostics for maybank card', () => {
     const data = exports.buildFallbackData('XL Rewards Card', { defaultCategory: 'Others', selectedCategories: [] });
     assert.equal(data.diagnostics.non_debit_rows, 0);

--- a/apps/userscript/__tests__/sync-core.test.js
+++ b/apps/userscript/__tests__/sync-core.test.js
@@ -4,7 +4,7 @@ import { loadExports, normalizeValue } from './helpers/load-userscript-exports.j
 
 describe('userscript sync core', () => {
   it('derives sync totals and snapshot defaults', async () => {
-    const { calculateMonthlyTotalsForSync, buildSyncCardSnapshot } = await loadExports();
+    const { calculateMonthlyTotalsForSync, buildSyncCardSnapshot, buildSyncCardFingerprint } = await loadExports();
     const transactions = [
       { posting_month: '2024-01', amount_value: 12.5, category: 'Dining' },
       { posting_date_iso: '2024-01-03', amount_value: 5.5 }
@@ -26,6 +26,51 @@ describe('userscript sync core', () => {
     });
     assert.equal(snapshot.defaultCategory, 'Travel');
     assert.deepEqual(normalizeValue(snapshot.selectedCategories), []);
+
+    const fingerprintA = buildSyncCardFingerprint('UOB', { defaultCategory: 'Travel' }, transactions);
+    const fingerprintB = buildSyncCardFingerprint(
+      'UOB',
+      { defaultCategory: 'Travel', merchantMap: {}, selectedCategories: [] },
+      [
+        { posting_date_iso: '2024-01-03', amount_value: 5.5 },
+        { posting_month: '2024-01', amount_value: 12.5, category: 'Dining' }
+      ]
+    );
+    assert.equal(fingerprintA, fingerprintB);
+  });
+
+  it('buildSyncCardFingerprint is stable for object key order', async () => {
+    const { buildSyncCardFingerprint } = await loadExports();
+
+    const cardSettingsA = {
+      selectedCategories: ['Dining', 'Travel'],
+      defaultCategory: 'Others',
+      merchantMap: {
+        Grab: 'Travel',
+        Starbucks: 'Dining'
+      }
+    };
+    const cardSettingsB = {
+      merchantMap: {
+        Starbucks: 'Dining',
+        Grab: 'Travel'
+      },
+      defaultCategory: 'Others',
+      selectedCategories: ['Dining', 'Travel']
+    };
+
+    const transactionsA = [
+      { posting_month: '2024-03', amount_value: 10, category: 'Dining' },
+      { posting_month: '2024-02', amount_value: 20, category: 'Travel' }
+    ];
+    const transactionsB = [
+      { posting_month: '2024-02', amount_value: 20, category: 'Travel' },
+      { posting_month: '2024-03', amount_value: 10, category: 'Dining' }
+    ];
+
+    const fingerprintA = buildSyncCardFingerprint('XL Rewards Card', cardSettingsA, transactionsA);
+    const fingerprintB = buildSyncCardFingerprint('XL Rewards Card', cardSettingsB, transactionsB);
+    assert.equal(fingerprintA, fingerprintB);
   });
 
   it('parses canonical and legacy payloads', async () => {

--- a/apps/userscript/__tests__/sync-core.test.js
+++ b/apps/userscript/__tests__/sync-core.test.js
@@ -49,4 +49,60 @@ describe('userscript sync core', () => {
     assert.equal(invalid.ok, false);
     assert.equal(invalid.format, 'invalid');
   });
+
+  it('syncActiveCardInBackground skips when sync is disabled or locked', async () => {
+    const { syncActiveCardInBackground } = await loadExports();
+
+    const disabledResult = await syncActiveCardInBackground(
+      { isEnabled: () => false },
+      'XL Rewards Card',
+      {},
+      []
+    );
+    assert.equal(disabledResult.attempted, false);
+    assert.equal(disabledResult.reason, 'sync_disabled');
+
+    const lockedResult = await syncActiveCardInBackground(
+      {
+        isEnabled: () => true,
+        isUnlocked: () => false,
+        tryUnlockFromRememberedCache: async () => false,
+        sync: async () => ({ success: true })
+      },
+      'XL Rewards Card',
+      {},
+      []
+    );
+    assert.equal(lockedResult.attempted, false);
+    assert.equal(lockedResult.reason, 'sync_locked');
+  });
+
+  it('syncActiveCardInBackground syncs active card payload after unlock', async () => {
+    const { syncActiveCardInBackground } = await loadExports();
+    let syncedPayload = null;
+    let unlocked = false;
+
+    const result = await syncActiveCardInBackground(
+      {
+        isEnabled: () => true,
+        isUnlocked: () => unlocked,
+        tryUnlockFromRememberedCache: async () => {
+          unlocked = true;
+          return true;
+        },
+        sync: async (payload) => {
+          syncedPayload = payload;
+          return { success: true };
+        }
+      },
+      'XL Rewards Card',
+      { defaultCategory: 'Others', selectedCategories: ['Local'], merchantMap: { GRAB: 'Local' } },
+      [{ posting_month: '2024-02', amount_value: 12.5, category: 'Local' }]
+    );
+
+    assert.equal(result.attempted, true);
+    assert.equal(result.success, true);
+    assert.equal(normalizeValue(syncedPayload).cards['XL Rewards Card'].defaultCategory, 'Others');
+    assert.equal(normalizeValue(syncedPayload).cards['XL Rewards Card'].monthlyTotals['2024-02'].total_amount, 12.5);
+  });
 });

--- a/apps/userscript/__tests__/sync-core.test.js
+++ b/apps/userscript/__tests__/sync-core.test.js
@@ -150,4 +150,23 @@ describe('userscript sync core', () => {
     assert.equal(normalizeValue(syncedPayload).cards['XL Rewards Card'].defaultCategory, 'Others');
     assert.equal(normalizeValue(syncedPayload).cards['XL Rewards Card'].monthlyTotals['2024-02'].total_amount, 12.5);
   });
+
+  it('shouldApplyBackgroundSyncCooldown only cools down attempted failures', async () => {
+    const { shouldApplyBackgroundSyncCooldown } = await loadExports();
+
+    assert.equal(shouldApplyBackgroundSyncCooldown({ attempted: false, success: false, reason: 'sync_disabled' }), false);
+    assert.equal(shouldApplyBackgroundSyncCooldown({ attempted: false, success: false, reason: 'sync_locked' }), false);
+    assert.equal(shouldApplyBackgroundSyncCooldown({ attempted: true, success: false, reason: 'sync_failed' }), true);
+    assert.equal(shouldApplyBackgroundSyncCooldown({ success: false }), true);
+    assert.equal(shouldApplyBackgroundSyncCooldown({ success: true, reason: 'synced' }), false);
+  });
+
+  it('shouldRetryBackgroundSyncAfterFlight requires dirty state and queued retry', async () => {
+    const { shouldRetryBackgroundSyncAfterFlight } = await loadExports();
+
+    assert.equal(shouldRetryBackgroundSyncAfterFlight(false, false), false);
+    assert.equal(shouldRetryBackgroundSyncAfterFlight(true, false), false);
+    assert.equal(shouldRetryBackgroundSyncAfterFlight(false, true), false);
+    assert.equal(shouldRetryBackgroundSyncAfterFlight(true, true), true);
+  });
 });

--- a/apps/userscript/__tests__/transactions-dom.test.js
+++ b/apps/userscript/__tests__/transactions-dom.test.js
@@ -55,6 +55,22 @@ describe('transaction DOM builders', () => {
     assert.equal(result.diagnostics.invalid_posting_date, 1);
   });
 
+  it('buildMaybankTransactions keeps identical rows as distinct transactions', () => {
+    const cardSettings = { defaultCategory: 'Others', merchantMap: {} };
+    const rows = [
+      makeRow([makeCell('01 Jan 2024'), makeCell('x'), makeCell('GRAB SGP'), makeCell('-SGD 10.00')]),
+      makeRow([makeCell('01 Jan 2024'), makeCell('x'), makeCell('GRAB SGP'), makeCell('-SGD 10.00')]),
+      makeRow([makeCell('01 Jan 2024'), makeCell('x'), makeCell('GRAB SGP'), makeCell('-SGD 10.00')])
+    ];
+    const tbody = makeTbody(rows);
+    const result = exports.buildMaybankTransactions(tbody, 'XL Rewards Card', cardSettings);
+    assert.equal(result.transactions.length, 3);
+    assert.deepEqual(
+      result.transactions.map((tx) => tx.ref_no),
+      result.transactions.map((_, index) => `${result.transactions[0].ref_no.replace(/#\d+$/, '')}#${index + 1}`)
+    );
+  });
+
   it('buildData wires summary and selected categories', () => {
     const cardSettings = { defaultCategory: 'Others', selectedCategories: ['Dining', ''], merchantMap: {}, transactions: {} };
     const rows = [

--- a/apps/userscript/bank-cc-limits-subcap-calculator.user.js
+++ b/apps/userscript/bank-cc-limits-subcap-calculator.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Bank CC Limits Subcap Calculator
 // @namespace    local
-// @version      0.7.1
+// @version      0.7.2
 // @description  Extract credit card transactions and manage subcap categories with optional sync
 // @author       laurenceputra
 // @downloadURL  https://raw.githubusercontent.com/laurenceputra/sg-cc-mile-subcaps-limits-viewer/main/apps/userscript/bank-cc-limits-subcap-calculator.user.js

--- a/apps/userscript/bank-cc-limits-subcap-calculator.user.js
+++ b/apps/userscript/bank-cc-limits-subcap-calculator.user.js
@@ -5050,6 +5050,8 @@
           });
       };
 
+      const preUpdateStoredTransactions = getStoredTransactions(cardName, initialCardSettings);
+      const preUpdateFingerprint = buildSyncCardFingerprint(cardName, initialCardSettings, preUpdateStoredTransactions);
       if (tableBody) {
         const initialData = buildData(tableBody, cardName, initialCardSettings);
         updateStoredTransactions(initialSettings, cardName, cardConfig, initialData.transactions);
@@ -5057,7 +5059,7 @@
       saveSettings(initialSettings);
       const initialStoredTransactions = getStoredTransactions(cardName, initialCardSettings);
       lastKnownCardFingerprint = buildSyncCardFingerprint(cardName, initialCardSettings, initialStoredTransactions);
-      if (tableBody) {
+      if (tableBody && lastKnownCardFingerprint !== preUpdateFingerprint) {
         hasUnsyncedCardChanges = true;
         attemptBackgroundSyncIfDirty();
       }

--- a/apps/userscript/bank-cc-limits-subcap-calculator.user.js
+++ b/apps/userscript/bank-cc-limits-subcap-calculator.user.js
@@ -1812,6 +1812,30 @@
     };
   }
 
+  function canonicalizeSyncValue(value) {
+    if (Array.isArray(value)) {
+      return value.map((entry) => canonicalizeSyncValue(entry));
+    }
+    if (!value || typeof value !== 'object') {
+      return value;
+    }
+    const normalized = {};
+    Object.keys(value)
+      .sort()
+      .forEach((key) => {
+        normalized[key] = canonicalizeSyncValue(value[key]);
+      });
+    return normalized;
+  }
+
+  function buildSyncCardFingerprint(cardName, cardSettings, storedTransactions) {
+    const snapshot = buildSyncCardSnapshot(cardName, cardSettings, storedTransactions);
+    return JSON.stringify({
+      cardName,
+      snapshot: canonicalizeSyncValue(snapshot)
+    });
+  }
+
   async function syncActiveCardInBackground(syncManager, cardName, cardSettings, storedTransactions) {
     if (!syncManager || typeof syncManager.isEnabled !== 'function' || !syncManager.isEnabled()) {
       return { attempted: false, success: false, reason: 'sync_disabled' };
@@ -1837,7 +1861,6 @@
       error: result?.error || ''
     };
   }
-
   function createSyncTab(syncManager, cardName, cardSettings, storedTransactions, THEME, onSyncStateChanged = () => {}) {
     ensureUiStyles(THEME);
     const container = document.createElement('div');
@@ -2103,6 +2126,8 @@
       validateServerUrl,
       calculateMonthlyTotalsForSync,
       buildSyncCardSnapshot,
+      canonicalizeSyncValue,
+      buildSyncCardFingerprint,
       syncActiveCardInBackground,
       getJwtTokenExpiryMs,
       SyncEngine,
@@ -4925,11 +4950,63 @@
 
       const initialSettings = loadSettings();
       const initialCardSettings = ensureCardSettings(initialSettings, cardName, cardConfig);
+      let backgroundSyncInFlight = false;
+      let hasUnsyncedCardChanges = false;
+      let lastKnownCardFingerprint = '';
+      let lastSyncedCardFingerprint = '';
+
+      const getCurrentSyncState = () => {
+        const settings = loadSettings();
+        const cardSettings = ensureCardSettings(settings, cardName, cardConfig);
+        const storedTransactions = getStoredTransactions(cardName, cardSettings);
+        const fingerprint = buildSyncCardFingerprint(cardName, cardSettings, storedTransactions);
+        return { cardSettings, storedTransactions, fingerprint };
+      };
+
+      const attemptBackgroundSyncIfDirty = () => {
+        if (!hasUnsyncedCardChanges || backgroundSyncInFlight) {
+          return;
+        }
+
+        const { cardSettings, storedTransactions, fingerprint } = getCurrentSyncState();
+        if (lastSyncedCardFingerprint && fingerprint === lastSyncedCardFingerprint) {
+          lastKnownCardFingerprint = fingerprint;
+          hasUnsyncedCardChanges = false;
+          return;
+        }
+
+        lastKnownCardFingerprint = fingerprint;
+        backgroundSyncInFlight = true;
+        syncActiveCardInBackground(syncManager, cardName, cardSettings, storedTransactions)
+          .then((result) => {
+            if (!result?.success) {
+              return;
+            }
+            lastSyncedCardFingerprint = fingerprint;
+            if (lastKnownCardFingerprint === fingerprint) {
+              hasUnsyncedCardChanges = false;
+            }
+          })
+          .catch(() => {})
+          .finally(() => {
+            backgroundSyncInFlight = false;
+            if (hasUnsyncedCardChanges) {
+              attemptBackgroundSyncIfDirty();
+            }
+          });
+      };
+
       if (tableBody) {
         const initialData = buildData(tableBody, cardName, initialCardSettings);
         updateStoredTransactions(initialSettings, cardName, cardConfig, initialData.transactions);
       }
       saveSettings(initialSettings);
+      const initialStoredTransactions = getStoredTransactions(cardName, initialCardSettings);
+      lastKnownCardFingerprint = buildSyncCardFingerprint(cardName, initialCardSettings, initialStoredTransactions);
+      if (tableBody) {
+        hasUnsyncedCardChanges = true;
+        attemptBackgroundSyncIfDirty();
+      }
 
       const initialStoredTransactions = getStoredTransactions(cardName, initialCardSettings);
       syncActiveCardInBackground(syncManager, cardName, initialCardSettings, initialStoredTransactions).catch(() => {});
@@ -5028,10 +5105,18 @@
             data = buildFallbackData(cardName, cardSettings);
           }
           saveSettings(settings);
+          const storedTransactions = getStoredTransactions(cardName, cardSettings);
+          const latestFingerprint = buildSyncCardFingerprint(cardName, cardSettings, storedTransactions);
+          if (latestTableBody && latestFingerprint !== lastKnownCardFingerprint) {
+            hasUnsyncedCardChanges = true;
+          }
+          lastKnownCardFingerprint = latestFingerprint;
+          if (latestTableBody) {
+            attemptBackgroundSyncIfDirty();
+          }
           if (syncManager.isEnabled() && !syncManager.isUnlocked() && syncManager.hasRememberedUnlockCache()) {
             await syncManager.tryUnlockFromRememberedCache();
           }
-          const storedTransactions = getStoredTransactions(cardName, cardSettings);
           createOverlay(
             data,
             settings,

--- a/apps/userscript/bank-cc-limits-subcap-calculator.user.js
+++ b/apps/userscript/bank-cc-limits-subcap-calculator.user.js
@@ -1861,6 +1861,25 @@
       error: result?.error || ''
     };
   }
+
+  function shouldApplyBackgroundSyncCooldown(result) {
+    if (result?.success) {
+      return false;
+    }
+
+    const reason = typeof result?.reason === 'string' ? result.reason : '';
+    if (reason === 'sync_disabled' || reason === 'sync_locked') {
+      return false;
+    }
+
+    const attempted = result?.attempted !== false;
+    return attempted || reason === 'sync_failed';
+  }
+
+  function shouldRetryBackgroundSyncAfterFlight(hasUnsyncedCardChanges, backgroundSyncRetryRequested) {
+    return hasUnsyncedCardChanges === true && backgroundSyncRetryRequested === true;
+  }
+
   function createSyncTab(syncManager, cardName, cardSettings, storedTransactions, THEME, onSyncStateChanged = () => {}) {
     ensureUiStyles(THEME);
     const container = document.createElement('div');
@@ -2129,6 +2148,8 @@
       canonicalizeSyncValue,
       buildSyncCardFingerprint,
       syncActiveCardInBackground,
+      shouldApplyBackgroundSyncCooldown,
+      shouldRetryBackgroundSyncAfterFlight,
       getJwtTokenExpiryMs,
       SyncEngine,
       SyncManager,
@@ -4961,6 +4982,7 @@
       let lastSyncedCardFingerprint = '';
       let lastFailedSyncFingerprint = '';
       let lastAutoSyncAttemptAt = 0;
+      let backgroundSyncRetryRequested = false;
       const AUTO_SYNC_RETRY_COOLDOWN_MS = 30000;
 
       const getCurrentSyncState = () => {
@@ -4972,7 +4994,12 @@
       };
 
       const attemptBackgroundSyncIfDirty = () => {
-        if (!hasUnsyncedCardChanges || backgroundSyncInFlight) {
+        if (!hasUnsyncedCardChanges) {
+          return;
+        }
+
+        if (backgroundSyncInFlight) {
+          backgroundSyncRetryRequested = true;
           return;
         }
 
@@ -4995,11 +5022,14 @@
 
         lastKnownCardFingerprint = fingerprint;
         backgroundSyncInFlight = true;
-        lastAutoSyncAttemptAt = now;
+        backgroundSyncRetryRequested = false;
         syncActiveCardInBackground(syncManager, cardName, cardSettings, storedTransactions)
           .then((result) => {
             if (!result?.success) {
-              lastFailedSyncFingerprint = fingerprint;
+              if (shouldApplyBackgroundSyncCooldown(result)) {
+                lastFailedSyncFingerprint = fingerprint;
+                lastAutoSyncAttemptAt = Date.now();
+              }
               return;
             }
             lastSyncedCardFingerprint = fingerprint;
@@ -5010,9 +5040,13 @@
           })
           .catch(() => {
             lastFailedSyncFingerprint = fingerprint;
+            lastAutoSyncAttemptAt = Date.now();
           })
           .finally(() => {
             backgroundSyncInFlight = false;
+            if (shouldRetryBackgroundSyncAfterFlight(hasUnsyncedCardChanges, backgroundSyncRetryRequested)) {
+              attemptBackgroundSyncIfDirty();
+            }
           });
       };
 
@@ -5329,7 +5363,9 @@
         moveOthersToEnd,
         getCategoryDisplayOrder,
         resolveCategory,
-        calculateSummary
+        calculateSummary,
+        shouldApplyBackgroundSyncCooldown,
+        shouldRetryBackgroundSyncAfterFlight
       });
       return;
     }

--- a/apps/userscript/bank-cc-limits-subcap-calculator.user.js
+++ b/apps/userscript/bank-cc-limits-subcap-calculator.user.js
@@ -1812,6 +1812,32 @@
     };
   }
 
+  async function syncActiveCardInBackground(syncManager, cardName, cardSettings, storedTransactions) {
+    if (!syncManager || typeof syncManager.isEnabled !== 'function' || !syncManager.isEnabled()) {
+      return { attempted: false, success: false, reason: 'sync_disabled' };
+    }
+
+    if (!cardName || typeof cardName !== 'string') {
+      return { attempted: false, success: false, reason: 'invalid_card' };
+    }
+
+    if (!syncManager.isUnlocked()) {
+      const unlockedFromCache = await syncManager.tryUnlockFromRememberedCache();
+      if (!unlockedFromCache && !syncManager.isUnlocked()) {
+        return { attempted: false, success: false, reason: 'sync_locked' };
+      }
+    }
+
+    const activeCardPayload = buildSyncCardSnapshot(cardName, cardSettings, storedTransactions);
+    const result = await syncManager.sync({ cards: { [cardName]: activeCardPayload } });
+    return {
+      attempted: true,
+      success: Boolean(result?.success),
+      reason: result?.success ? 'synced' : 'sync_failed',
+      error: result?.error || ''
+    };
+  }
+
   function createSyncTab(syncManager, cardName, cardSettings, storedTransactions, THEME, onSyncStateChanged = () => {}) {
     ensureUiStyles(THEME);
     const container = document.createElement('div');
@@ -2077,6 +2103,7 @@
       validateServerUrl,
       calculateMonthlyTotalsForSync,
       buildSyncCardSnapshot,
+      syncActiveCardInBackground,
       getJwtTokenExpiryMs,
       SyncEngine,
       SyncManager,
@@ -3188,6 +3215,24 @@
       return raw.replace(/^ref\s*no\s*:\s*/i, '');
     }
 
+    function hasMaybankSyntheticOccurrence(refNo) {
+      return /#\d+$/.test(refNo);
+    }
+
+    function normalizeStoredRefNo(refNo, cardName) {
+      const normalized = normalizeKey(normalizeRefNo(refNo));
+      if (!normalized) {
+        return '';
+      }
+      if (cardName !== 'XL Rewards Card') {
+        return normalized;
+      }
+      if (!/^MB:/.test(normalized) || hasMaybankSyntheticOccurrence(normalized)) {
+        return normalized;
+      }
+      return `${normalized}#1`;
+    }
+
     function parseAmount(amountText) {
       if (!amountText) {
         return null;
@@ -3454,6 +3499,7 @@
         invalid_amount: 0,
         missing_ref_no: 0
       };
+      const syntheticRefCounts = new Map();
 
       const transactions = rows
         .map((row, index) => {
@@ -3494,7 +3540,10 @@
             return null;
           }
 
-          const refNo = buildMaybankSyntheticRefNo(postingDateIso, description, amountValue);
+          const baseRefNo = buildMaybankSyntheticRefNo(postingDateIso, description, amountValue);
+          const occurrence = (syntheticRefCounts.get(baseRefNo) || 0) + 1;
+          syntheticRefCounts.set(baseRefNo, occurrence);
+          const refNo = `${baseRefNo}#${occurrence}`;
           const category = resolveCategory(description, cardSettings, cardName);
 
           return {
@@ -3652,7 +3701,14 @@
         const entry = cardSettings.transactions[refNo];
         const parsedDate = getParsedDate(entry);
         if (parsedDate && isWithinCutoff(parsedDate, cutoff)) {
-          nextStored[refNo] = entry;
+          const normalizedRefNo = normalizeStoredRefNo(entry?.ref_no || refNo, cardName);
+          if (!normalizedRefNo) {
+            return;
+          }
+          nextStored[normalizedRefNo] = {
+            ...entry,
+            ref_no: normalizedRefNo
+          };
         }
       });
 
@@ -3664,7 +3720,7 @@
         if (!parsedDate || !isWithinCutoff(parsedDate, cutoff)) {
           return;
         }
-        const key = normalizeKey(tx.ref_no);
+        const key = normalizeStoredRefNo(tx.ref_no, cardName);
         if (!key) {
           return;
         }
@@ -3689,7 +3745,7 @@
 
       Object.keys(stored).forEach((key) => {
         const entry = stored[key] || {};
-        const normalizedRefNo = normalizeKey(normalizeRefNo(entry.ref_no || key));
+        const normalizedRefNo = normalizeStoredRefNo(entry.ref_no || key, cardName);
         if (!normalizedRefNo) {
           return;
         }
@@ -4874,6 +4930,9 @@
         updateStoredTransactions(initialSettings, cardName, cardConfig, initialData.transactions);
       }
       saveSettings(initialSettings);
+
+      const initialStoredTransactions = getStoredTransactions(cardName, initialCardSettings);
+      syncActiveCardInBackground(syncManager, cardName, initialCardSettings, initialStoredTransactions).catch(() => {});
 
       let refreshInProgress = false;
       let refreshPending = false;

--- a/apps/userscript/bank-cc-limits-subcap-calculator.user.js
+++ b/apps/userscript/bank-cc-limits-subcap-calculator.user.js
@@ -5008,9 +5008,6 @@
         attemptBackgroundSyncIfDirty();
       }
 
-      const initialStoredTransactions = getStoredTransactions(cardName, initialCardSettings);
-      syncActiveCardInBackground(syncManager, cardName, initialCardSettings, initialStoredTransactions).catch(() => {});
-
       let refreshInProgress = false;
       let refreshPending = false;
       const observedTableBodyXPaths = preferredTableBodyXPath

--- a/apps/userscript/bank-cc-limits-subcap-calculator.user.js
+++ b/apps/userscript/bank-cc-limits-subcap-calculator.user.js
@@ -2174,6 +2174,7 @@
           '/html/body/div/div/div[1]/div[1]/div[3]/div[2]/div[1]/div/div[1]/div[1]/div[2]/div[2]/span',
           '//*[contains(translate(normalize-space(.), "ABCDEFGHIJKLMNOPQRSTUVWXYZ", "abcdefghijklmnopqrstuvwxyz"), "xl rewards card")][1]'
         ],
+        strictPrimaryCardNameXPath: true,
         requireVisibleCardName: true,
         observeCardContext: true,
         tableBodyXPaths: [
@@ -2990,6 +2991,7 @@
       if (!cardNameXPaths.length) {
         return null;
       }
+      const strictPrimaryCardNameXPath = profile?.strictPrimaryCardNameXPath === true;
       const selectFromNode = (node, xpath) => {
         if (!node) {
           return null;
@@ -3006,6 +3008,9 @@
         const resolved = selectFromNode(node, xpath);
         if (resolved && resolved.name) {
           return resolved;
+        }
+        if (strictPrimaryCardNameXPath && node) {
+          return null;
         }
       }
       return null;

--- a/apps/userscript/bank-cc-limits-subcap-calculator.user.js
+++ b/apps/userscript/bank-cc-limits-subcap-calculator.user.js
@@ -4954,6 +4954,9 @@
       let hasUnsyncedCardChanges = false;
       let lastKnownCardFingerprint = '';
       let lastSyncedCardFingerprint = '';
+      let lastFailedSyncFingerprint = '';
+      let lastAutoSyncAttemptAt = 0;
+      const AUTO_SYNC_RETRY_COOLDOWN_MS = 30000;
 
       const getCurrentSyncState = () => {
         const settings = loadSettings();
@@ -4971,28 +4974,40 @@
         const { cardSettings, storedTransactions, fingerprint } = getCurrentSyncState();
         if (lastSyncedCardFingerprint && fingerprint === lastSyncedCardFingerprint) {
           lastKnownCardFingerprint = fingerprint;
+          lastFailedSyncFingerprint = '';
           hasUnsyncedCardChanges = false;
+          return;
+        }
+
+        const now = Date.now();
+        if (
+          lastFailedSyncFingerprint === fingerprint &&
+          lastAutoSyncAttemptAt > 0 &&
+          now - lastAutoSyncAttemptAt < AUTO_SYNC_RETRY_COOLDOWN_MS
+        ) {
           return;
         }
 
         lastKnownCardFingerprint = fingerprint;
         backgroundSyncInFlight = true;
+        lastAutoSyncAttemptAt = now;
         syncActiveCardInBackground(syncManager, cardName, cardSettings, storedTransactions)
           .then((result) => {
             if (!result?.success) {
+              lastFailedSyncFingerprint = fingerprint;
               return;
             }
             lastSyncedCardFingerprint = fingerprint;
+            lastFailedSyncFingerprint = '';
             if (lastKnownCardFingerprint === fingerprint) {
               hasUnsyncedCardChanges = false;
             }
           })
-          .catch(() => {})
+          .catch(() => {
+            lastFailedSyncFingerprint = fingerprint;
+          })
           .finally(() => {
             backgroundSyncInFlight = false;
-            if (hasUnsyncedCardChanges) {
-              attemptBackgroundSyncIfDirty();
-            }
           });
       };
 
@@ -5108,11 +5123,11 @@
             hasUnsyncedCardChanges = true;
           }
           lastKnownCardFingerprint = latestFingerprint;
-          if (latestTableBody) {
-            attemptBackgroundSyncIfDirty();
-          }
           if (syncManager.isEnabled() && !syncManager.isUnlocked() && syncManager.hasRememberedUnlockCache()) {
             await syncManager.tryUnlockFromRememberedCache();
+          }
+          if (latestTableBody) {
+            attemptBackgroundSyncIfDirty();
           }
           createOverlay(
             data,


### PR DESCRIPTION
## Summary
- Make Maybank synthetic reference numbers deterministic per identical row by appending occurrence suffixes (`#1`, `#2`, ...) and normalize stored legacy synthetic refs to the `#1` format.
- Add guarded background sync for the active card during supported page load when sync is enabled and unlock is available, so data refresh does not depend on opening the overlay.
- Add userscript tests covering background sync gating/success and Maybank synthetic-ref dedupe/migration behavior.

## Validation
- Ran `npm run test:userscript`.
- Result: 265 tests passed, 0 failed.