### PR TITLE
fix(api): align sync contract

### DIFF
--- a/apps/backend/README.md
+++ b/apps/backend/README.md
@@ -102,6 +102,21 @@ Security controls (validation, CSRF, rate limits, audit logging, headers) are do
 - `GET /shared/mappings/:cardType` - Get shared merchant mappings
 - `POST /shared/mappings/contribute` - Contribute merchant mappings
 
+### Verified public contract notes
+
+- `POST /auth/register` and `POST /auth/login` return `{ token, userId, tier }`, where `userId` is numeric.
+- `POST /auth/login` and `POST /auth/refresh` manage the `ccSubcapRefreshToken` cookie with `HttpOnly`, `SameSite=Strict`, `Path=/auth`, 30-day lifetime, and `Secure` in production.
+- `PUT /sync/data` requires `encryptedData.ciphertext`, `encryptedData.iv`, and `encryptedData.salt`; legacy `encryptedData.tag` remains accepted and is preserved if present.
+- `GET /shared/mappings/:cardType` returns camelCase public fields (`merchant`, `merchantNormalized`, `suggestedCategory`, `cardType`, `contributionCount`, `lastUpdated`) and also includes `category` as a compatibility alias for `suggestedCategory`.
+- `POST /shared/mappings/contribute` accepts canonical `suggestedCategory` and legacy `category`, normalizing `cardType` to uppercase before persistence.
+
+### Failure-mode highlights
+
+- `POST /auth/login` returns `401` for invalid credentials; `POST /auth/refresh` returns `401` for missing, expired, revoked, or reused refresh cookies.
+- `PUT /sync/data` returns `400` for invalid encrypted payloads and `409` with `{ error: "Version conflict", currentVersion }` on optimistic-lock conflicts.
+- `GET /shared/mappings/:cardType` returns `400` for invalid card types.
+- Full verified request/response shapes live in `../contracts/sync-api.md`.
+
 ### User (requires auth)
 - `DELETE /user/data` - Delete all user data
 - `GET /user/export` - Export user data

--- a/apps/backend/src/__tests__/workers/api-contract-worker.test.js
+++ b/apps/backend/src/__tests__/workers/api-contract-worker.test.js
@@ -1,0 +1,315 @@
+import { describe, test } from 'node:test';
+import assert from 'node:assert/strict';
+import crypto from 'node:crypto';
+import app from '../../index.js';
+import {
+  TEST_ADMIN_EMAIL,
+  TEST_ADMIN_PASSWORD,
+  createTestDatabase,
+  createTestEnv,
+  disposeTestDatabase,
+  expectJwtLike,
+  expectStatus,
+  fetchJson
+} from './test-utils.js';
+
+function randomEmail(prefix = 'contract') {
+  return `${prefix}-${crypto.randomBytes(6).toString('hex')}@example.com`;
+}
+
+function createEncryptedData() {
+  return {
+    iv: crypto.randomBytes(16).toString('base64'),
+    ciphertext: crypto.randomBytes(32).toString('base64'),
+    salt: crypto.randomBytes(16).toString('base64'),
+    tag: crypto.randomBytes(8).toString('base64')
+  };
+}
+
+function extractCookieValue(setCookieHeader, name) {
+  if (!setCookieHeader) return null;
+  const match = setCookieHeader.match(new RegExp(`${name}=([^;]+)`));
+  return match ? match[1] : null;
+}
+
+function assertRefreshCookie(setCookieHeader, context) {
+  assert.ok(setCookieHeader, `${context}: Set-Cookie header should be present`);
+  assert.ok(setCookieHeader.includes('ccSubcapRefreshToken='), `${context}: refresh cookie name should be present`);
+  assert.ok(setCookieHeader.includes('Max-Age=2592000'), `${context}: refresh cookie should use 30 day max age`);
+  assert.ok(setCookieHeader.includes('Path=/auth'), `${context}: refresh cookie should be scoped to /auth`);
+  assert.ok(setCookieHeader.includes('HttpOnly'), `${context}: refresh cookie should be HttpOnly`);
+  assert.ok(setCookieHeader.includes('SameSite=Strict'), `${context}: refresh cookie should be strict same-site`);
+}
+
+async function registerUser(env, email, passwordHash, origin = 'https://pib.uob.com.sg') {
+  return fetchJson(app, env, '/auth/register', {
+    method: 'POST',
+    origin,
+    body: { email, passwordHash }
+  }, 200, 'register user');
+}
+
+async function loginUser(env, email, passwordHash, origin = 'https://pib.uob.com.sg') {
+  return fetchJson(app, env, '/auth/login', {
+    method: 'POST',
+    origin,
+    body: { email, passwordHash }
+  }, 200, 'login user');
+}
+
+async function loginAdmin(env) {
+  return fetchJson(app, env, '/admin/auth/login', {
+    method: 'POST',
+    body: { email: TEST_ADMIN_EMAIL, password: TEST_ADMIN_PASSWORD }
+  }, 200, 'admin login');
+}
+
+describe('Workers userscript API contract', () => {
+  test('verifies auth register/login/refresh contract', async () => {
+    const { mf, db } = await createTestDatabase();
+    try {
+      const env = { ...createTestEnv(), db };
+      const email = randomEmail();
+      const passwordHash = crypto.randomBytes(32).toString('hex');
+
+      const { response: registerRes, json: registerJson } = await registerUser(env, email, passwordHash);
+      assert.equal(registerRes.headers.get('Set-Cookie'), null, 'register should not set refresh cookie');
+      expectJwtLike(registerJson.token, 'register token');
+      assert.equal(typeof registerJson.userId, 'number', 'register userId should be numeric');
+      assert.equal(registerJson.tier, 'free');
+
+      const { response: loginRes, json: loginJson } = await loginUser(env, email, passwordHash);
+      expectJwtLike(loginJson.token, 'login token');
+      assert.equal(typeof loginJson.userId, 'number', 'login userId should be numeric');
+      assert.equal(loginJson.tier, 'free');
+      const loginCookie = loginRes.headers.get('Set-Cookie');
+      assertRefreshCookie(loginCookie, 'login');
+      const refreshToken = extractCookieValue(loginCookie, 'ccSubcapRefreshToken');
+      assert.ok(refreshToken, 'login should return refresh token cookie value');
+
+      const missingCookieRefreshRes = await app.fetch(new Request('http://localhost/auth/refresh', {
+        method: 'POST',
+        headers: {
+          'Origin': 'https://pib.uob.com.sg'
+        }
+      }), env);
+      const missingCookieRefreshJson = await missingCookieRefreshRes.json();
+      expectStatus(missingCookieRefreshRes, 401, 'refresh without cookie');
+      assert.equal(missingCookieRefreshJson.error, 'Unauthorized');
+
+      const refreshRes = await app.fetch(new Request('http://localhost/auth/refresh', {
+        method: 'POST',
+        headers: {
+          'Origin': 'https://pib.uob.com.sg',
+          'Cookie': `ccSubcapRefreshToken=${refreshToken}`
+        }
+      }), env);
+      const refreshJson = await refreshRes.json();
+      expectStatus(refreshRes, 200, 'refresh with cookie');
+      expectJwtLike(refreshJson.token, 'refreshed access token');
+      const rotatedCookie = refreshRes.headers.get('Set-Cookie');
+      assertRefreshCookie(rotatedCookie, 'refresh');
+      const rotatedToken = extractCookieValue(rotatedCookie, 'ccSubcapRefreshToken');
+      assert.ok(rotatedToken, 'refresh should rotate refresh token');
+      assert.notEqual(rotatedToken, refreshToken, 'refresh should rotate cookie value');
+    } finally {
+      await disposeTestDatabase(mf);
+    }
+  });
+
+  test('verifies cap policy contract', async () => {
+    const { mf, db } = await createTestDatabase();
+    try {
+      const env = { ...createTestEnv(), db };
+      const res = await app.fetch(new Request('http://localhost/meta/cap-policy'), env);
+      const json = await res.json();
+
+      expectStatus(res, 200, 'cap policy');
+      assert.equal(typeof json.version, 'number');
+      assert.equal(typeof json.thresholds.warningRatio, 'number');
+      assert.equal(typeof json.thresholds.criticalRatio, 'number');
+      assert.equal(typeof json.styles.warning.background, 'string');
+      assert.equal(json.cards["LADY'S SOLITAIRE CARD"].mode, 'per-category');
+      assert.equal(json.cards['XL Rewards Card'].mode, 'combined');
+    } finally {
+      await disposeTestDatabase(mf);
+    }
+  });
+
+  test('verifies sync data contract and conflict handling', async () => {
+    const { mf, db } = await createTestDatabase();
+    try {
+      const env = { ...createTestEnv(), db };
+      const email = randomEmail('sync');
+      const passwordHash = crypto.randomBytes(32).toString('hex');
+      await registerUser(env, email, passwordHash);
+      const { json: loginJson } = await loginUser(env, email, passwordHash);
+      const token = loginJson.token;
+
+      const initialGetRes = await app.fetch(new Request('http://localhost/sync/data', {
+        method: 'GET',
+        headers: {
+          'Authorization': `Bearer ${token}`,
+          'Origin': 'https://pib.uob.com.sg'
+        }
+      }), env);
+      const initialGetJson = await initialGetRes.json();
+      expectStatus(initialGetRes, 200, 'initial sync read');
+      assert.equal(initialGetJson.encryptedData, null);
+      assert.equal(initialGetJson.version, 0);
+
+      const { json: missingSaltJson } = await fetchJson(app, env, '/sync/data', {
+        method: 'PUT',
+        token,
+        body: {
+          encryptedData: {
+            iv: crypto.randomBytes(16).toString('base64'),
+            ciphertext: crypto.randomBytes(32).toString('base64')
+          },
+          version: 1
+        }
+      }, 400, 'sync write without salt');
+      assert.match(missingSaltJson.error, /salt/i);
+
+      const encryptedData = createEncryptedData();
+      const putRes = await app.fetch(new Request('http://localhost/sync/data', {
+        method: 'PUT',
+        headers: {
+          'Authorization': `Bearer ${token}`,
+          'Content-Type': 'application/json',
+          'Origin': 'https://pib.uob.com.sg'
+        },
+        body: JSON.stringify({ encryptedData, version: 1 })
+      }), env);
+      const putJson = await putRes.json();
+      expectStatus(putRes, 200, 'sync write');
+      assert.equal(putJson.success, true);
+      assert.equal(putJson.version, 1);
+
+      const secondGetRes = await app.fetch(new Request('http://localhost/sync/data', {
+        method: 'GET',
+        headers: {
+          'Authorization': `Bearer ${token}`,
+          'Origin': 'https://pib.uob.com.sg'
+        }
+      }), env);
+      const secondGetJson = await secondGetRes.json();
+      expectStatus(secondGetRes, 200, 'sync read after write');
+      assert.deepEqual(secondGetJson.encryptedData, encryptedData);
+      assert.equal(secondGetJson.version, 1);
+      assert.equal(typeof secondGetJson.updatedAt, 'number');
+
+      const stalePutRes = await app.fetch(new Request('http://localhost/sync/data', {
+        method: 'PUT',
+        headers: {
+          'Authorization': `Bearer ${token}`,
+          'Content-Type': 'application/json',
+          'Origin': 'https://pib.uob.com.sg'
+        },
+        body: JSON.stringify({ encryptedData, version: 1 })
+      }), env);
+      const stalePutJson = await stalePutRes.json();
+      expectStatus(stalePutRes, 409, 'stale sync write');
+      assert.equal(stalePutJson.error, 'Version conflict');
+      assert.equal(stalePutJson.currentVersion, 1);
+    } finally {
+      await disposeTestDatabase(mf);
+    }
+  });
+
+  test('verifies shared mappings contract with canonical response fields and legacy request alias', async () => {
+    const { mf, db } = await createTestDatabase();
+    try {
+      const env = { ...createTestEnv(), db };
+      const email = randomEmail('mappings');
+      const passwordHash = crypto.randomBytes(32).toString('hex');
+      await registerUser(env, email, passwordHash);
+      const { json: loginJson } = await loginUser(env, email, passwordHash);
+      const token = loginJson.token;
+
+      const { json: contributeJson } = await fetchJson(app, env, '/shared/mappings/contribute', {
+        method: 'POST',
+        token,
+        body: {
+          mappings: [
+            {
+              merchantRaw: 'Coffee Bean',
+              category: 'dining',
+              cardType: 'one'
+            }
+          ]
+        }
+      }, 200, 'shared mapping contribution');
+      assert.equal(contributeJson.success, true);
+      assert.equal(contributeJson.contributed, 1);
+
+      const { json: invalidContributionJson } = await fetchJson(app, env, '/shared/mappings/contribute', {
+        method: 'POST',
+        token,
+        body: {
+          mappings: [
+            {
+              merchantRaw: 'Coffee Bean',
+              cardType: 'ONE'
+            }
+          ]
+        }
+      }, 400, 'shared mapping contribution without category');
+      assert.match(invalidContributionJson.error, /suggestedCategory/i);
+
+      const { json: adminLoginJson } = await loginAdmin(env);
+      expectJwtLike(adminLoginJson.token, 'admin token');
+      const approveRes = await app.fetch(new Request('http://localhost/admin/mappings/approve', {
+        method: 'POST',
+        headers: {
+          'Authorization': `Bearer ${adminLoginJson.token}`,
+          'Content-Type': 'application/json',
+          'Origin': 'https://pib.uob.com.sg'
+        },
+        body: JSON.stringify({
+          merchantNormalized: 'coffee bean',
+          category: 'dining',
+          cardType: 'ONE'
+        })
+      }), env);
+      const approveJson = await approveRes.json();
+      expectStatus(approveRes, 200, 'approve shared mapping');
+      assert.equal(approveJson.success, true);
+
+      const getRes = await app.fetch(new Request('http://localhost/shared/mappings/one', {
+        method: 'GET',
+        headers: {
+          'Authorization': `Bearer ${token}`,
+          'Origin': 'https://pib.uob.com.sg'
+        }
+      }), env);
+      const getJson = await getRes.json();
+      expectStatus(getRes, 200, 'shared mapping read');
+      assert.ok(Array.isArray(getJson.mappings));
+      assert.equal(getJson.mappings.length, 1);
+      assert.deepEqual(getJson.mappings[0], {
+        merchant: 'coffee bean',
+        merchantNormalized: 'coffee bean',
+        suggestedCategory: 'dining',
+        category: 'dining',
+        cardType: 'ONE',
+        contributionCount: 1,
+        lastUpdated: getJson.mappings[0].lastUpdated
+      });
+      assert.equal(typeof getJson.mappings[0].lastUpdated, 'number');
+
+      const invalidCardTypeRes = await app.fetch(new Request('http://localhost/shared/mappings/not-a-card', {
+        method: 'GET',
+        headers: {
+          'Authorization': `Bearer ${token}`,
+          'Origin': 'https://pib.uob.com.sg'
+        }
+      }), env);
+      const invalidCardTypeJson = await invalidCardTypeRes.json();
+      expectStatus(invalidCardTypeRes, 400, 'invalid shared mapping card type');
+      assert.equal(invalidCardTypeJson.error, 'Invalid card type');
+    } finally {
+      await disposeTestDatabase(mf);
+    }
+  });
+});

--- a/apps/backend/src/__tests__/workers/auth-sync-worker.test.js
+++ b/apps/backend/src/__tests__/workers/auth-sync-worker.test.js
@@ -19,6 +19,7 @@ function createEncryptedData() {
   return {
     iv: crypto.randomBytes(16).toString('base64'),
     ciphertext: crypto.randomBytes(32).toString('base64'),
+    salt: crypto.randomBytes(16).toString('base64'),
     tag: crypto.randomBytes(8).toString('base64')
   };
 }

--- a/apps/backend/src/__tests__/workers/user-admin-worker.test.js
+++ b/apps/backend/src/__tests__/workers/user-admin-worker.test.js
@@ -16,6 +16,7 @@ function createEncryptedData() {
   return {
     iv: crypto.randomBytes(16).toString('base64'),
     ciphertext: crypto.randomBytes(32).toString('base64'),
+    salt: crypto.randomBytes(16).toString('base64'),
     tag: crypto.randomBytes(8).toString('base64')
   };
 }

--- a/apps/backend/src/__tests__/workers/validation-utils.test.js
+++ b/apps/backend/src/__tests__/workers/validation-utils.test.js
@@ -10,7 +10,7 @@ describe('validation utils', () => {
   });
 
   it('validates encrypted data and device ids', () => {
-    const encryptedError = validateInput({ iv: 'a', ciphertext: 'b', tag: 123 }, 'encryptedData');
+    const encryptedError = validateInput({ iv: 'a', ciphertext: 'b', salt: 'c', tag: 123 }, 'encryptedData');
     assert.strictEqual(typeof encryptedError, 'string', 'should return error string for invalid encrypted data');
     assert.match(encryptedError, /tag/, 'error should mention the invalid tag field');
 

--- a/apps/backend/src/api/shared-mappings.js
+++ b/apps/backend/src/api/shared-mappings.js
@@ -3,15 +3,37 @@ import { normalizeMerchant } from '../lib/merchant-normalization.js';
 import { validateFields, validateInput } from '../middleware/validation.js';
 
 const sharedMappings = new Hono();
+const ALLOWED_SHARED_MAPPING_CARD_TYPES = new Set(['ONE', 'LADY', 'PPV', 'SOLITAIRE']);
+
+function normalizeCardType(cardType) {
+  return typeof cardType === 'string' ? cardType.trim().toUpperCase() : cardType;
+}
+
+function toPublicSharedMapping(row) {
+  const merchantNormalized = row?.merchant_normalized ?? '';
+  const suggestedCategory = row?.suggested_category ?? '';
+  const cardType = normalizeCardType(row?.card_type ?? '');
+
+  return {
+    merchant: merchantNormalized,
+    merchantNormalized,
+    suggestedCategory,
+    category: suggestedCategory,
+    cardType,
+    contributionCount: Number(row?.contribution_count ?? 0),
+    lastUpdated: Number(row?.updated_at ?? 0)
+  };
+}
 
 sharedMappings.get('/mappings/:cardType', async (c) => {
   // SECURITY: Validate immediately after extraction, before any processing
-  const cardType = c.req.param('cardType');
-  const cardTypeError = validateInput(cardType, 'cardType');
+  const rawCardType = c.req.param('cardType');
+  const cardTypeError = validateInput(rawCardType, 'cardType');
   if (cardTypeError) {
     return c.json({ error: cardTypeError }, 400);
   }
-  if (!['ONE', 'LADY', 'PPV', 'SOLITAIRE'].includes(cardType.toUpperCase())) {
+  const cardType = normalizeCardType(rawCardType);
+  if (!ALLOWED_SHARED_MAPPING_CARD_TYPES.has(cardType)) {
     return c.json({ error: 'Invalid card type' }, 400);
   }
   
@@ -19,7 +41,7 @@ sharedMappings.get('/mappings/:cardType', async (c) => {
   
   try {
     const mappings = await db.getSharedMappings(cardType);
-    return c.json({ mappings });
+    return c.json({ mappings: mappings.map(toPublicSharedMapping) });
   } catch (error) {
     console.error('[SharedMappings] Get error:', error);
     return c.json({ error: 'Failed to fetch shared mappings' }, 500);
@@ -45,15 +67,19 @@ sharedMappings.post('/mappings/contribute',
       const merchantRaw = mapping.merchantRaw || mapping.merchantNormalized || mapping.merchant;
       const merchant = mapping.merchant || mapping.merchantNormalized || mapping.merchantRaw;
       const merchantNormalized = normalizeMerchant(mapping.merchantNormalized || mapping.merchantRaw || mapping.merchant || '');
+      const suggestedCategory = mapping.suggestedCategory ?? mapping.category;
+      const cardType = normalizeCardType(mapping.cardType);
       const merchantError = validateInput(merchantNormalized, 'merchantName');
       if (merchantError) {
         throw new Error(merchantError);
       }
       return {
-        ...mapping,
         merchantRaw,
         merchant,
-        merchantNormalized
+        merchantNormalized,
+        suggestedCategory,
+        category: suggestedCategory,
+        cardType
       };
     });
 

--- a/apps/backend/src/middleware/validation.js
+++ b/apps/backend/src/middleware/validation.js
@@ -208,11 +208,13 @@ export const schemas = {
       // Validate required structure
       if (!value.iv || typeof value.iv !== 'string') return 'Encrypted data must contain valid iv';
       if (!value.ciphertext || typeof value.ciphertext !== 'string') return 'Encrypted data must contain valid ciphertext';
+      if (!value.salt || typeof value.salt !== 'string') return 'Encrypted data must contain valid salt';
       if (value.tag && typeof value.tag !== 'string') return 'Encrypted data tag must be a string';
       
       // Check for control characters in string fields
       if (CONTROL_CHARS_REGEX.test(value.iv)) return 'IV contains invalid control characters';
       if (CONTROL_CHARS_REGEX.test(value.ciphertext)) return 'Ciphertext contains invalid control characters';
+      if (CONTROL_CHARS_REGEX.test(value.salt)) return 'Salt contains invalid control characters';
       if (value.tag && CONTROL_CHARS_REGEX.test(value.tag)) return 'Tag contains invalid control characters';
       
       // Check size (stringified JSON)
@@ -246,17 +248,20 @@ export const schemas = {
           return `Mapping item ${i}: Merchant name must be a string`;
         }
         
-        // Validate category field
-        if (item.category !== undefined) {
-          const categoryError = schemas.category.validate(item.category);
-          if (categoryError) return `Mapping item ${i}: ${categoryError}`;
+        // Validate category field (support suggestedCategory as canonical public name)
+        const categoryValue = item.suggestedCategory ?? item.category;
+        if (categoryValue === undefined) {
+          return `Mapping item ${i}: suggestedCategory is required`;
         }
+        const categoryError = schemas.category.validate(categoryValue);
+        if (categoryError) return `Mapping item ${i}: ${categoryError}`;
         
         // Validate cardType field
-        if (item.cardType !== undefined) {
-          const cardTypeError = schemas.cardType.validate(item.cardType);
-          if (cardTypeError) return `Mapping item ${i}: ${cardTypeError}`;
+        if (item.cardType === undefined) {
+          return `Mapping item ${i}: cardType is required`;
         }
+        const cardTypeError = schemas.cardType.validate(item.cardType);
+        if (cardTypeError) return `Mapping item ${i}: ${cardTypeError}`;
       }
       
       return null;

--- a/apps/backend/src/storage/db.js
+++ b/apps/backend/src/storage/db.js
@@ -148,7 +148,9 @@ export class Database {
 
     for (const mapping of mappings) {
       const merchantRaw = mapping.merchantRaw || mapping.merchantNormalized || mapping.merchant;
-      await this.run(insertSql, userId, merchantRaw, mapping.category, mapping.cardType);
+      const category = mapping.suggestedCategory ?? mapping.category;
+      const cardType = typeof mapping.cardType === 'string' ? mapping.cardType.toUpperCase() : mapping.cardType;
+      await this.run(insertSql, userId, merchantRaw, category, cardType);
     }
   }
 

--- a/apps/contracts/schemas/shared-mapping.schema.json
+++ b/apps/contracts/schemas/shared-mapping.schema.json
@@ -2,34 +2,55 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "apps/contracts/schemas/shared-mapping.schema.json",
   "title": "SharedMapping",
+  "description": "Canonical public shared mapping object for the shared mappings API. suggestedCategory is canonical; category remains a legacy alias for compatibility.",
   "type": "object",
-  "required": ["merchant", "suggestedCategory", "cardType"],
+  "required": ["suggestedCategory", "cardType"],
+  "anyOf": [
+    {
+      "required": ["merchant"]
+    },
+    {
+      "required": ["merchantRaw"]
+    },
+    {
+      "required": ["merchantNormalized"]
+    }
+  ],
   "properties": {
     "merchant": {
       "type": "string",
-      "minLength": 1
+      "minLength": 1,
+      "description": "Public merchant key. For approved shared mappings this is the normalized merchant string."
     },
     "merchantRaw": {
-      "type": "string"
+      "type": "string",
+      "minLength": 1
     },
     "merchantNormalized": {
-      "type": "string"
+      "type": "string",
+      "minLength": 1
     },
     "suggestedCategory": {
       "type": "string",
       "minLength": 1
     },
+    "category": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Legacy alias for suggestedCategory."
+    },
     "contributionCount": {
-      "type": "number",
+      "type": "integer",
       "minimum": 0
     },
     "lastUpdated": {
-      "type": "number",
+      "type": "integer",
       "exclusiveMinimum": 0
     },
     "cardType": {
       "type": "string",
-      "minLength": 1
+      "enum": ["ONE", "LADY", "PPV", "SOLITAIRE"],
+      "description": "Public API normalizes cardType to uppercase."
     }
   },
   "additionalProperties": true

--- a/apps/contracts/schemas/sync-payload.schema.json
+++ b/apps/contracts/schemas/sync-payload.schema.json
@@ -2,19 +2,22 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "apps/contracts/schemas/sync-payload.schema.json",
   "title": "SyncPayload",
+  "description": "Canonical decrypted payload stored inside encryptedData for /sync/data. The transport envelope requires encryptedData.ciphertext, encryptedData.iv, and encryptedData.salt; legacy encryptedData.tag may still be present.",
   "type": "object",
   "required": ["version", "deviceId", "timestamp", "data"],
   "properties": {
     "version": {
-      "type": "number",
+      "type": "integer",
       "minimum": 0
     },
     "deviceId": {
       "type": "string",
-      "minLength": 1
+      "minLength": 1,
+      "maxLength": 128,
+      "pattern": "^[A-Za-z0-9_-]+$"
     },
     "timestamp": {
-      "type": "number",
+      "type": "integer",
       "exclusiveMinimum": 0
     },
     "data": {
@@ -22,7 +25,8 @@
       "required": ["cards"],
       "properties": {
         "cards": {
-          "type": "object"
+          "type": "object",
+          "description": "Card-keyed sync payload map."
         }
       },
       "additionalProperties": true

--- a/apps/contracts/sync-api.md
+++ b/apps/contracts/sync-api.md
@@ -1,10 +1,17 @@
 # Sync API Contract
 
-This directory documents the HTTP contract between:
+This directory documents the verified HTTP contract between:
 - `apps/userscript/bank-cc-limits-subcap-calculator.user.js`
 - `apps/backend`
 
 Coupling is contract-only (HTTP + JSON schema). There is no shared runtime package.
+
+## Endpoint-wide rules
+
+- Protected endpoints require `Authorization: Bearer <jwt>`.
+- State-changing requests must send JSON with `Content-Type: application/json`.
+- Userscript requests without an `Origin` header must send `X-CC-Userscript: tampermonkey-v1`.
+- Refresh tokens are stored in the `ccSubcapRefreshToken` cookie scoped to `/auth`.
 
 ## Endpoints
 
@@ -14,37 +21,55 @@ Request body:
 - `passwordHash` (string)
 - `tier` (optional: `free` or `paid`)
 
-Response body:
-- `token` (string)
-- `userId` (string)
+Success response body (`200`):
+- `token` (string JWT)
+- `userId` (number)
 - `tier` (`free` or `paid`)
+
+Behavior notes:
+- Does **not** set the refresh token cookie.
+
+Failure modes:
+- `400` invalid input or duplicate registration
+- `500` registration failure
 
 ### `POST /auth/login`
 Request body:
 - `email` (string)
 - `passwordHash` (string)
 
-Response body:
-- `token` (string)
-- `userId` (string)
+Success response body (`200`):
+- `token` (string JWT)
+- `userId` (number)
 - `tier` (`free` or `paid`)
 
 Behavior notes:
-- Sets a refresh token cookie (`ccSubcapRefreshToken`, HttpOnly, SameSite=Strict, Secure in production) scoped to `/auth`.
+- Sets a refresh token cookie named `ccSubcapRefreshToken`.
+- Cookie attributes: `HttpOnly`, `SameSite=Strict`, `Path=/auth`, `Max-Age=2592000`, and `Secure` in production.
+
+Failure modes:
+- `400` invalid input
+- `401` invalid credentials
+- `500` authentication failure
 
 ### `POST /auth/refresh`
 Request:
-- Uses the refresh token cookie (`ccSubcapRefreshToken`).
+- No JSON body.
+- Uses the `ccSubcapRefreshToken` refresh cookie.
 
-Response body:
-- `token` (string)
+Success response body (`200`):
+- `token` (string JWT)
 
 Behavior notes:
-- Rotates the refresh token on every refresh and extends expiry by 30 days.
-- Returns `401` if the refresh token is missing, expired, revoked, or reused.
+- Rotates the refresh token cookie on every successful refresh.
+- Extends refresh-cookie expiry by 30 days from the refresh event.
+
+Failure modes:
+- `401` missing, expired, revoked, or reused refresh cookie
+- `500` authentication failure
 
 ### `GET /meta/cap-policy`
-Response body:
+Success response body (`200`):
 - `version` (number)
 - `thresholds` (object)
   - `warningRatio` (number)
@@ -54,36 +79,47 @@ Response body:
     - `background` (string color token)
     - `border` (string color token)
     - `text` (string color token)
-- `cards` (object, keyed by card name)
+- `cards` (object keyed by card name)
   - each entry has:
     - `mode` (`per-category` or `combined`)
     - `cap` (number)
 
 Behavior notes:
 - This endpoint is the backend-owned source of truth for cap display policy.
-- Current policy includes:
-  - `LADY'S SOLITAIRE CARD`: per-category cap of `750`
-  - `XL Rewards Card`: combined cap of `1000`
-- Clients may cache the last successful policy and fallback to embedded defaults if unavailable.
+- Clients may cache the last successful policy and fall back to embedded defaults if unavailable.
 
 ### `GET /sync/data` (auth required)
-Response body:
-- `encryptedData` (object or `null`)
-  - `ciphertext` (base64 string)
-  - `iv` (base64 string)
-  - `salt` (base64 string)
-- `version` (number)
-- `updatedAt` (number, optional)
+Success response body (`200`) when no blob exists:
+- `encryptedData` (`null`)
+- `version` (`0`)
 
-### `PUT /sync/data` (auth required)
-Request body:
+Success response body (`200`) when a blob exists:
 - `encryptedData` (object)
   - `ciphertext` (base64 string)
   - `iv` (base64 string)
   - `salt` (base64 string)
-- `version` (number, optimistic lock version)
+  - `tag` (optional legacy base64 string)
+- `version` (number)
+- `updatedAt` (number, optional Unix timestamp)
 
-Success response body:
+Behavior notes:
+- The encrypted transport envelope requires `ciphertext`, `iv`, and `salt`.
+- Legacy `tag` values are still accepted and preserved when already stored.
+
+Failure modes:
+- `401` missing or invalid bearer token
+- `500` sync read failure
+
+### `PUT /sync/data` (auth required)
+Request body:
+- `encryptedData` (object)
+  - `ciphertext` (base64 string, required)
+  - `iv` (base64 string, required)
+  - `salt` (base64 string, required)
+  - `tag` (optional legacy base64 string)
+- `version` (number, optimistic-lock version)
+
+Success response body (`200`):
 - `success` (boolean)
 - `version` (number)
 
@@ -95,44 +131,75 @@ Behavior notes:
 - This endpoint only persists encrypted sync blobs (`sync_blobs`).
 - It does not create shared mapping contributions.
 - Userscript sync payload remains under `data.cards` and is card-keyed.
-- Current client behavior syncs only the active card from the current portal page, while preserving other remote card keys.
+- Current client behavior syncs only the active card from the current portal page while preserving other remote card keys.
 - Synced card data is minimized to settings + aggregates (`selectedCategories`, `defaultCategory`, `merchantMap`, `monthlyTotals`) and excludes raw `transactions`.
 - First-login/bootstrap restore is pull-only (`GET /sync/data`) and does not issue `PUT /sync/data` during the restore step.
-- On `409 Version conflict`, client behavior is: pull latest remote state, perform client-side 3-way merge for active-card settings, and require explicit user choice for overlapping edits (including per-merchant choices in `merchantMap`) before retrying `PUT /sync/data`.
+- On `409 Version conflict`, client behavior is: pull latest remote state, perform client-side 3-way merge for active-card settings, and require explicit user choice for overlapping edits before retrying `PUT /sync/data`.
+
+Failure modes:
+- `400` invalid JSON or missing required encrypted fields
+- `401` missing or invalid bearer token
+- `409` optimistic-lock conflict
+- `500` sync write failure
 
 ### `GET /shared/mappings/:cardType` (auth required)
 Path param:
 - `cardType` one of `ONE`, `LADY`, `PPV`, `SOLITAIRE`
 
-Response body:
+Success response body (`200`):
 - `mappings` (array of mapping objects)
+  - `merchant` (string)
+  - `merchantNormalized` (string)
+  - `suggestedCategory` (string, canonical public field)
+  - `category` (string, legacy alias of `suggestedCategory`)
+  - `cardType` (string, uppercase)
+  - `contributionCount` (number)
+  - `lastUpdated` (number Unix timestamp)
+
+Behavior notes:
+- Public responses are camelCase, even though the backing D1 rows are snake_case.
+- `cardType` is normalized to uppercase before lookup.
+
+Failure modes:
+- `400` invalid card type
+- `401` missing or invalid bearer token
+- `500` shared mapping read failure
 
 ### `POST /shared/mappings/contribute` (auth required)
 Request body:
 - `mappings` (array of objects)
-  - `merchantRaw` (string)
-  - `merchant` (string)
-  - `merchantNormalized` (string)
-  - `suggestedCategory` (string)
+  - one of `merchant`, `merchantRaw`, or `merchantNormalized` (string)
+  - `suggestedCategory` (string, canonical public field)
+  - `category` (string, optional legacy alias for `suggestedCategory`)
   - `cardType` (string)
 
-Response body:
+Success response body (`200`):
 - `success` (boolean)
 - `contributed` (number, optional)
 
 Behavior notes:
-- This is the only API path that writes user mapping contributions (`mapping_contributions`).
+- `suggestedCategory` is the canonical public request field.
+- The backend still accepts legacy `category` in request payloads for backward compatibility.
+- `cardType` is normalized to uppercase before persistence.
+- This is the only public API path that writes user mapping contributions (`mapping_contributions`).
 - `shared_mappings` entries are created/updated via admin approval flows, not direct user sync.
+
+Failure modes:
+- `400` invalid mapping payload
+- `401` missing or invalid bearer token
+- `500` contribution failure
 
 ## Required normalization and validation behavior
 
 - Merchant normalization: lowercase, collapse internal whitespace to single spaces, trim, then remove characters not matching `[A-Za-z0-9_\s-]`.
-- Canonical sync payload structure is defined by `schemas/sync-payload.schema.json` after decryption.
+- Canonical decrypted sync payload structure is defined by `schemas/sync-payload.schema.json`.
 - Clients should remain backward compatible with known legacy decrypted payload layouts:
   - `{ cards: { ... } }`
+  - `{ data: { cards: { ... } } }`
   - `{ "<CARD_NAME>": { selectedCategories, defaultCategory, merchantMap, ... } }`
-- On successful sync using a legacy payload, clients should write back canonical envelope format on the next `PUT /sync/data` to migrate stored blobs.
-- Shared mapping structure must validate against `schemas/shared-mapping.schema.json` for API-level interchange.
+- On successful sync using a legacy decrypted payload, clients should write back canonical envelope format on the next `PUT /sync/data` to migrate stored blobs.
+- Shared mapping structure must validate against `schemas/shared-mapping.schema.json`.
+- `suggestedCategory` is canonical for shared mapping interchange; `category` remains a supported alias where documented.
 - Sync clients must derive decrypt keys using the payload `salt` field before AES-GCM decryption.
 
 ## Versioning


### PR DESCRIPTION
## Summary
- add route-level userscript API contract tests that exercise the documented public endpoints through `app.fetch`
- normalize shared mapping payloads to canonical camelCase public fields while preserving legacy `category` requests and legacy sync `tag` payloads
- tighten sync encrypted-data validation to require `ciphertext`, `iv`, and `salt`, then update the contract docs and schemas to match the verified implementation

## Verified
- npm --prefix apps/backend test
- npm --prefix apps/backend run test:quality
- npm run test:anti-patterns
- npm run prepush:verify