### PR TITLE
fix(api): enforce shared mapping card types

### DIFF
--- a/apps/backend/README.md
+++ b/apps/backend/README.md
@@ -108,7 +108,7 @@ Security controls (validation, CSRF, rate limits, audit logging, headers) are do
 - `POST /auth/login` and `POST /auth/refresh` manage the `ccSubcapRefreshToken` cookie with `HttpOnly`, `SameSite=Strict`, `Path=/auth`, 30-day lifetime, and `Secure` in production.
 - `PUT /sync/data` requires `encryptedData.ciphertext`, `encryptedData.iv`, and `encryptedData.salt`; legacy `encryptedData.tag` remains accepted and is preserved if present.
 - `GET /shared/mappings/:cardType` returns camelCase public fields (`merchant`, `merchantNormalized`, `suggestedCategory`, `cardType`, `contributionCount`, `lastUpdated`) and also includes `category` as a compatibility alias for `suggestedCategory`.
-- `POST /shared/mappings/contribute` accepts canonical `suggestedCategory` and legacy `category`, normalizing `cardType` to uppercase before persistence.
+- `POST /shared/mappings/contribute` accepts canonical `suggestedCategory` and legacy `category`, accepts supported `cardType` values case-insensitively, rejects unsupported values, and normalizes persisted `cardType` to uppercase.
 
 ### Failure-mode highlights
 

--- a/apps/backend/src/__tests__/workers/api-contract-worker.test.js
+++ b/apps/backend/src/__tests__/workers/api-contract-worker.test.js
@@ -257,6 +257,21 @@ describe('Workers userscript API contract', () => {
       }, 400, 'shared mapping contribution without category');
       assert.match(invalidContributionJson.error, /suggestedCategory/i);
 
+      const { json: invalidCardContributionJson } = await fetchJson(app, env, '/shared/mappings/contribute', {
+        method: 'POST',
+        token,
+        body: {
+          mappings: [
+            {
+              merchantRaw: 'Coffee Bean',
+              suggestedCategory: 'dining',
+              cardType: 'foo'
+            }
+          ]
+        }
+      }, 400, 'shared mapping contribution with invalid card type');
+      assert.match(invalidCardContributionJson.error, /invalid card type/i);
+
       const { json: adminLoginJson } = await loginAdmin(env);
       expectJwtLike(adminLoginJson.token, 'admin token');
       const approveRes = await app.fetch(new Request('http://localhost/admin/mappings/approve', {
@@ -269,7 +284,7 @@ describe('Workers userscript API contract', () => {
         body: JSON.stringify({
           merchantNormalized: 'coffee bean',
           category: 'dining',
-          cardType: 'ONE'
+          cardType: 'one'
         })
       }), env);
       const approveJson = await approveRes.json();

--- a/apps/backend/src/__tests__/workers/shared-mappings-utils.test.js
+++ b/apps/backend/src/__tests__/workers/shared-mappings-utils.test.js
@@ -1,10 +1,20 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import { normalizeMerchant } from '../../lib/merchant-normalization.js';
+import {
+  isAllowedSharedMappingCardType,
+  normalizeSharedMappingCardType
+} from '../../lib/shared-mapping-card-type.js';
 
 describe('shared mappings utils', () => {
   it('normalizes merchant names', () => {
     assert.equal(normalizeMerchant('  Cafe--Mocha!!  '), 'cafe--mocha');
     assert.equal(normalizeMerchant('SOME   STORE   NAME'), 'some store name');
+  });
+
+  it('normalizes and validates supported card types', () => {
+    assert.equal(normalizeSharedMappingCardType(' one '), 'ONE');
+    assert.equal(isAllowedSharedMappingCardType('lady'), true);
+    assert.equal(isAllowedSharedMappingCardType('foo'), false);
   });
 });

--- a/apps/backend/src/api/admin.js
+++ b/apps/backend/src/api/admin.js
@@ -1,4 +1,8 @@
 import { Hono } from 'hono';
+import {
+  isAllowedSharedMappingCardType,
+  normalizeSharedMappingCardType
+} from '../lib/shared-mapping-card-type.js';
 import { validateFields } from '../middleware/validation.js';
 import { adminAuthMiddleware } from '../middleware/auth.js';
 import { logAuditEvent, AuditEventType } from '../audit/logger.js';
@@ -62,22 +66,30 @@ admin.post('/mappings/approve',
   }),
   async (c) => {
   const { merchantNormalized, category, cardType } = c.get('validatedBody') || await c.req.json();
+  const normalizedCardType = normalizeSharedMappingCardType(cardType);
 
   const db = c.get('db');
   
   try {
-    await db.approveMappings(merchantNormalized, category, cardType);
+    if (!isAllowedSharedMappingCardType(normalizedCardType)) {
+      return c.json({ error: 'Invalid card type' }, 400);
+    }
+
+    await db.approveMappings(merchantNormalized, category, normalizedCardType);
     
     // Audit log admin approval
     await logAuditEvent(db, {
       eventType: AuditEventType.ADMIN_MAPPING_APPROVE,
       request: c.req.raw,
       userId: null, // Admin action, no user ID
-      details: { merchantNormalized, category, cardType }
+      details: { merchantNormalized, category, cardType: normalizedCardType }
     });
     
     return c.json({ success: true });
   } catch (error) {
+    if (error?.message === 'Invalid card type') {
+      return c.json({ error: error.message }, 400);
+    }
     console.error('[Admin] Approve error:', error);
     return c.json({ error: 'Failed to approve mapping' }, 500);
   }

--- a/apps/backend/src/api/shared-mappings.js
+++ b/apps/backend/src/api/shared-mappings.js
@@ -1,18 +1,17 @@
 import { Hono } from 'hono';
 import { normalizeMerchant } from '../lib/merchant-normalization.js';
+import {
+  isAllowedSharedMappingCardType,
+  normalizeSharedMappingCardType
+} from '../lib/shared-mapping-card-type.js';
 import { validateFields, validateInput } from '../middleware/validation.js';
 
 const sharedMappings = new Hono();
-const ALLOWED_SHARED_MAPPING_CARD_TYPES = new Set(['ONE', 'LADY', 'PPV', 'SOLITAIRE']);
-
-function normalizeCardType(cardType) {
-  return typeof cardType === 'string' ? cardType.trim().toUpperCase() : cardType;
-}
 
 function toPublicSharedMapping(row) {
   const merchantNormalized = row?.merchant_normalized ?? '';
   const suggestedCategory = row?.suggested_category ?? '';
-  const cardType = normalizeCardType(row?.card_type ?? '');
+  const cardType = normalizeSharedMappingCardType(row?.card_type ?? '');
 
   return {
     merchant: merchantNormalized,
@@ -32,8 +31,8 @@ sharedMappings.get('/mappings/:cardType', async (c) => {
   if (cardTypeError) {
     return c.json({ error: cardTypeError }, 400);
   }
-  const cardType = normalizeCardType(rawCardType);
-  if (!ALLOWED_SHARED_MAPPING_CARD_TYPES.has(cardType)) {
+  const cardType = normalizeSharedMappingCardType(rawCardType);
+  if (!isAllowedSharedMappingCardType(cardType)) {
     return c.json({ error: 'Invalid card type' }, 400);
   }
   
@@ -68,7 +67,7 @@ sharedMappings.post('/mappings/contribute',
       const merchant = mapping.merchant || mapping.merchantNormalized || mapping.merchantRaw;
       const merchantNormalized = normalizeMerchant(mapping.merchantNormalized || mapping.merchantRaw || mapping.merchant || '');
       const suggestedCategory = mapping.suggestedCategory ?? mapping.category;
-      const cardType = normalizeCardType(mapping.cardType);
+      const cardType = normalizeSharedMappingCardType(mapping.cardType);
       const merchantError = validateInput(merchantNormalized, 'merchantName');
       if (merchantError) {
         throw new Error(merchantError);

--- a/apps/backend/src/lib/shared-mapping-card-type.js
+++ b/apps/backend/src/lib/shared-mapping-card-type.js
@@ -1,0 +1,9 @@
+export const ALLOWED_SHARED_MAPPING_CARD_TYPES = new Set(['ONE', 'LADY', 'PPV', 'SOLITAIRE']);
+
+export function normalizeSharedMappingCardType(cardType) {
+  return typeof cardType === 'string' ? cardType.trim().toUpperCase() : cardType;
+}
+
+export function isAllowedSharedMappingCardType(cardType) {
+  return ALLOWED_SHARED_MAPPING_CARD_TYPES.has(normalizeSharedMappingCardType(cardType));
+}

--- a/apps/backend/src/middleware/validation.js
+++ b/apps/backend/src/middleware/validation.js
@@ -8,6 +8,7 @@
  */
 
 import { rateLimitConfig } from './rate-limit-config.js';
+import { isAllowedSharedMappingCardType, normalizeSharedMappingCardType } from '../lib/shared-mapping-card-type.js';
 
 // RFC 5321 compliant email regex (simplified but practical)
 const EMAIL_REGEX = /^[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$/;
@@ -171,6 +172,9 @@ export const schemas = {
       if (value.length === 0) return 'Card type cannot be empty';
       if (value.length > 100) return 'Card type exceeds maximum length (100 characters)';
       if (CONTROL_CHARS_REGEX.test(value)) return 'Card type contains invalid control characters';
+      if (!isAllowedSharedMappingCardType(normalizeSharedMappingCardType(value))) {
+        return 'Invalid card type';
+      }
       return null;
     }
   },

--- a/apps/backend/src/storage/db.js
+++ b/apps/backend/src/storage/db.js
@@ -1,3 +1,8 @@
+import {
+  isAllowedSharedMappingCardType,
+  normalizeSharedMappingCardType
+} from '../lib/shared-mapping-card-type.js';
+
 export class Database {
   constructor(db) {
     this.db = db;
@@ -184,6 +189,11 @@ export class Database {
   }
 
   async approveMappings(merchantNormalized, category, cardType) {
+    const normalizedCardType = normalizeSharedMappingCardType(cardType);
+    if (!isAllowedSharedMappingCardType(normalizedCardType)) {
+      throw new Error('Invalid card type');
+    }
+
     await this.run(
       `
         INSERT INTO shared_mappings (merchant_normalized, suggested_category, card_type, status, contribution_count)
@@ -195,7 +205,7 @@ export class Database {
       `,
       merchantNormalized,
       category,
-      cardType
+      normalizedCardType
     );
   }
 

--- a/apps/contracts/sync-api.md
+++ b/apps/contracts/sync-api.md
@@ -171,7 +171,7 @@ Request body:
   - one of `merchant`, `merchantRaw`, or `merchantNormalized` (string)
   - `suggestedCategory` (string, canonical public field)
   - `category` (string, optional legacy alias for `suggestedCategory`)
-  - `cardType` (string)
+  - `cardType` (`ONE`, `LADY`, `PPV`, or `SOLITAIRE`; case-insensitive on input)
 
 Success response body (`200`):
 - `success` (boolean)
@@ -180,9 +180,9 @@ Success response body (`200`):
 Behavior notes:
 - `suggestedCategory` is the canonical public request field.
 - The backend still accepts legacy `category` in request payloads for backward compatibility.
-- `cardType` is normalized to uppercase before persistence.
+- `cardType` accepts supported lowercase values, rejects unsupported values, and is normalized to uppercase before persistence.
 - This is the only public API path that writes user mapping contributions (`mapping_contributions`).
-- `shared_mappings` entries are created/updated via admin approval flows, not direct user sync.
+- `shared_mappings` entries are created/updated via admin approval flows, which also normalize supported `cardType` values before persistence.
 
 Failure modes:
 - `400` invalid mapping payload


### PR DESCRIPTION
## Summary
- enforce the shared-mapping card-type contract in validation, admin approval, and persistence
- normalize admin approvals to uppercase so approved mappings remain readable through the public shared-mappings endpoint
- extend worker contract coverage for invalid contribution card types and lowercase admin approval

## Verification
- npm --prefix apps/backend test
- npm --prefix apps/backend run test:quality
- npm run test:anti-patterns
- npm run prepush:verify