### PR TITLE
chore(lint): widen repo lint coverage

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,19 +1,10 @@
 {
   "root": true,
   "env": {
-    "browser": true,
     "es2022": true
   },
   "parserOptions": {
-    "ecmaVersion": "latest",
-    "sourceType": "script"
-  },
-  "globals": {
-    "GM_getValue": "readonly",
-    "GM_setValue": "readonly",
-    "GM_deleteValue": "readonly",
-    "GM_xmlhttpRequest": "readonly",
-    "GM_addStyle": "readonly"
+    "ecmaVersion": "latest"
   },
   "extends": [
     "eslint:recommended"
@@ -22,5 +13,38 @@
     "no-undef": "error",
     "no-unused-vars": "off",
     "no-prototype-builtins": "off"
-  }
+  },
+  "overrides": [
+    {
+      "files": [
+        "apps/userscript/bank-cc-limits-subcap-calculator.user.js"
+      ],
+      "env": {
+        "browser": true
+      },
+      "parserOptions": {
+        "sourceType": "script"
+      },
+      "globals": {
+        "GM_getValue": "readonly",
+        "GM_setValue": "readonly",
+        "GM_deleteValue": "readonly",
+        "GM_xmlhttpRequest": "readonly",
+        "GM_addStyle": "readonly"
+      }
+    },
+    {
+      "files": [
+        "check-test-antipatterns.mjs",
+        "scripts/**/*.mjs",
+        "apps/backend/scripts/**/*.mjs"
+      ],
+      "env": {
+        "node": true
+      },
+      "parserOptions": {
+        "sourceType": "module"
+      }
+    }
+  ]
 }

--- a/.github/workflows/userscript-lint.yml
+++ b/.github/workflows/userscript-lint.yml
@@ -1,10 +1,13 @@
-name: Userscript Lint
+name: Repo Lint
 
 on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
     paths:
       - "apps/userscript/**"
+      - "scripts/**"
+      - "check-test-antipatterns.mjs"
+      - "apps/backend/scripts/**"
       - ".eslintrc.json"
       - "package.json"
       - "package-lock.json"
@@ -13,6 +16,9 @@ on:
     branches: [main]
     paths:
       - "apps/userscript/**"
+      - "scripts/**"
+      - "check-test-antipatterns.mjs"
+      - "apps/backend/scripts/**"
       - ".eslintrc.json"
       - "package.json"
       - "package-lock.json"
@@ -23,7 +29,7 @@ permissions:
   contents: read
 
 jobs:
-  lint-userscript:
+  lint-repo:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -37,5 +43,5 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Run userscript lint gate
-        run: npm run lint:userscript
+      - name: Run repo lint gate
+        run: npm run lint

--- a/package.json
+++ b/package.json
@@ -9,9 +9,10 @@
   ],
   "scripts": {
     "build": "npm run build --workspaces --if-present",
-    "lint": "npm run lint:userscript && npm run lint --workspaces --if-present",
+    "lint": "npm run lint:repo && npm run lint --workspaces --if-present",
+    "lint:repo": "eslint --max-warnings=0 apps/userscript/bank-cc-limits-subcap-calculator.user.js check-test-antipatterns.mjs \"scripts/**/*.mjs\" \"apps/backend/scripts/**/*.mjs\"",
     "lint:userscript": "eslint --max-warnings=0 apps/userscript/bank-cc-limits-subcap-calculator.user.js",
-    "prepush:verify": "npm run lint:userscript",
+    "prepush:verify": "npm run lint",
     "test:quality:backend": "npm --prefix apps/backend run test:quality",
     "test": "npm run test --workspaces --if-present",
     "test:userscript": "node --test apps/userscript/__tests__/*.test.js",


### PR DESCRIPTION
## Summary
- widen root ESLint coverage to include repo-owned Node utility and test scripts alongside the existing userscript target
- keep userscript behavior unchanged by moving browser globals into a userscript-only override and using Node/module overrides for tooling files
- align local pre-push and CI lint entry points so the same repo lint gate runs for script changes

## Scope and assumptions
- `npm run lint` was already green before this work and only covered `apps/userscript/bank-cc-limits-subcap-calculator.user.js`
- this PR intentionally broadens linting only to repo-owned Node utility/test scripts (`check-test-antipatterns.mjs`, `scripts/**/*.mjs`, `apps/backend/scripts/**/*.mjs`)
- pre-existing uncommitted commit-message hook/docs work in this branch was left out of the commit and PR

## Verification
- `npm run lint`
- `npm run test:commitmsg`
- `npm run docs:check:workflow`
- `npm run test:anti-patterns`
- `npm --prefix apps/backend run test:quality`
