### PR TITLE
feat: add local release note drafter

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,41 @@ Monorepo for the UOB credit-card userscript and the optional sync backend. Every
 - It catches high-confidence syntax patterns (for example callback execution during listener registration, synchronous timer callback shortcuts, direct worker-test imports from `apps/backend/src/api/*.js`, and broad alternation regex in `assert.rejects`).
 - It does **not** replace manual review for semantic anti-patterns (for example weak behavior assertions, permissive default mocks, or order-dependent shared state).
 
+## Release notes drafting
+
+Draft paste-ready Markdown release notes from local git history without creating tags, publishing a GitHub Release, or changing remote state.
+
+- Command: `npm run release-notes:draft -- --from <ref> [--to <ref>]`
+- `--from` is required and `--to` defaults to `HEAD`.
+- Commit subjects are grouped by conventional-commit type (`feat`, `fix`, `docs`, `chore`, and related types). Non-conforming subjects fall back to `Other Changes`.
+- Changed files are included under each bullet so the draft stays useful even when commit messages are terse.
+
+Example:
+
+```bash
+npm run release-notes:draft -- --from origin/main --to HEAD
+```
+
+Example output structure:
+
+```md
+# Release Notes Draft
+
+Range: `origin/main..HEAD`
+
+Summary:
+- 3 commits across 5 files
+- Features: 1
+- Fixes: 1
+- Documentation: 1
+
+## Features
+- Add a local release-note drafter (`abc1234`)
+  - Files: `scripts/draft-release-notes.mjs`, `package.json`
+```
+
+This tool only drafts notes locally for copy/paste into PR descriptions or GitHub Releases. It does not publish, tag, or automate a release.
+
 ## Disclaimer
 
 Not affiliated with UOB. Use only on your own accounts and comply with the bank’s Terms of Service.

--- a/package.json
+++ b/package.json
@@ -9,11 +9,13 @@
   ],
   "scripts": {
     "build": "npm run build --workspaces --if-present",
+    "release-notes:draft": "node scripts/draft-release-notes.mjs",
     "lint": "npm run lint:userscript && npm run lint --workspaces --if-present",
     "lint:userscript": "eslint --max-warnings=0 apps/userscript/bank-cc-limits-subcap-calculator.user.js",
     "prepush:verify": "npm run lint:userscript",
     "test:quality:backend": "npm --prefix apps/backend run test:quality",
     "test": "npm run test --workspaces --if-present",
+    "test:scripts": "node --test scripts/__tests__/*.test.mjs",
     "test:userscript": "node --test apps/userscript/__tests__/*.test.js",
     "test:userscript:coverage": "node --test --experimental-test-coverage apps/userscript/__tests__/*.test.js",
     "test:anti-patterns": "node check-test-antipatterns.mjs",

--- a/scripts/__tests__/draft-release-notes.test.mjs
+++ b/scripts/__tests__/draft-release-notes.test.mjs
@@ -1,0 +1,112 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import {
+  classifyCommit,
+  groupCommitsBySection,
+  parseCliArgs,
+  parseCommitHeader,
+  renderReleaseNotes,
+  summarizeFiles
+} from '../draft-release-notes.mjs';
+
+function createCommit(overrides = {}) {
+  return {
+    sha: 'abcdef1234567890',
+    shortSha: 'abcdef1',
+    subject: 'chore: default subject',
+    body: '',
+    files: ['scripts/draft-release-notes.mjs'],
+    ...overrides
+  };
+}
+
+describe('draft release notes helpers', () => {
+  it('parses conventional commit headers with scope and breaking marker', () => {
+    assert.deepEqual(parseCommitHeader('feat(cli)!: add release note drafter'), {
+      type: 'feat',
+      scope: 'cli',
+      breaking: true,
+      description: 'add release note drafter'
+    });
+  });
+
+  it('classifies conventional commits into release-note sections', () => {
+    const classified = classifyCommit(createCommit({ subject: 'docs(readme): explain local drafting' }));
+    assert.equal(classified.sectionKey, 'documentation');
+    assert.equal(classified.sectionTitle, 'Documentation');
+    assert.equal(classified.title, 'explain local drafting');
+    assert.deepEqual(classified.metadata, ['readme']);
+  });
+
+  it('falls back to other changes for non-conventional subjects', () => {
+    const classified = classifyCommit(createCommit({ subject: 'Merge branch main into release-notes' }));
+    assert.equal(classified.sectionKey, 'other');
+    assert.equal(classified.title, 'Merge branch main into release-notes');
+  });
+
+  it('groups sections in a deterministic display order', () => {
+    const sections = groupCommitsBySection([
+      createCommit({ subject: 'fix: handle empty range', shortSha: '1111111' }),
+      createCommit({ subject: 'feat: add release note script', shortSha: '2222222' }),
+      createCommit({ subject: 'docs: update readme', shortSha: '3333333' }),
+      createCommit({ subject: 'chore: add package script', shortSha: '4444444' })
+    ]);
+
+    assert.deepEqual(
+      sections.map((section) => ({ title: section.title, count: section.items.length })),
+      [
+        { title: 'Features', count: 1 },
+        { title: 'Fixes', count: 1 },
+        { title: 'Documentation', count: 1 },
+        { title: 'Maintenance', count: 1 }
+      ]
+    );
+  });
+
+  it('renders an empty range with a helpful message', () => {
+    const markdown = renderReleaseNotes({ fromRef: 'v1.0.0', toRef: 'HEAD', commits: [] });
+    assert.match(markdown, /Range: `v1\.0\.0\.\.HEAD`/);
+    assert.match(markdown, /0 commits across 0 files/);
+    assert.match(markdown, /_No commits found in this range\._/);
+  });
+
+  it('renders grouped markdown with commit metadata and files', () => {
+    const markdown = renderReleaseNotes({
+      fromRef: 'origin/main',
+      toRef: 'HEAD',
+      commits: [
+        createCommit({
+          subject: 'feat(cli)!: add release note drafter',
+          shortSha: '1234567',
+          files: ['scripts/draft-release-notes.mjs', 'package.json', 'README.md', 'docs/notes.md']
+        }),
+        createCommit({
+          subject: 'fix: handle empty ranges',
+          shortSha: '7654321',
+          files: ['scripts/draft-release-notes.mjs']
+        }),
+        createCommit({
+          subject: 'Ship release note drafts to the README',
+          shortSha: 'bbbbbbb',
+          files: ['README.md']
+        })
+      ]
+    });
+
+    assert.match(markdown, /Summary:\n- 3 commits across 4 files\n- Features: 1\n- Fixes: 1\n- Other Changes: 1/);
+    assert.match(markdown, /## Features/);
+    assert.match(markdown, /- add release note drafter \(`1234567`\) _cli, breaking_/);
+    assert.match(markdown, /Files: `scripts\/draft-release-notes\.mjs`, `package\.json`, `README\.md` \+1 more/);
+    assert.match(markdown, /## Other Changes/);
+  });
+
+  it('summarizes files without extra suffix when below the limit', () => {
+    assert.equal(summarizeFiles(['README.md', 'package.json']), '`README.md`, `package.json`');
+  });
+
+  it('requires a from ref when parsing CLI args', () => {
+    assert.throws(() => parseCliArgs(['--to', 'HEAD']), /--from is required/);
+    assert.deepEqual(parseCliArgs(['--from', 'origin/main']), { from: 'origin/main', to: 'HEAD' });
+  });
+});

--- a/scripts/draft-release-notes.mjs
+++ b/scripts/draft-release-notes.mjs
@@ -1,0 +1,228 @@
+import { execFileSync } from 'node:child_process';
+import process from 'node:process';
+import { pathToFileURL } from 'node:url';
+
+const SECTION_ORDER = [
+  { key: 'features', title: 'Features', types: ['feat'] },
+  { key: 'fixes', title: 'Fixes', types: ['fix', 'revert'] },
+  { key: 'documentation', title: 'Documentation', types: ['docs'] },
+  { key: 'performance', title: 'Performance', types: ['perf'] },
+  { key: 'refactors', title: 'Refactors', types: ['refactor'] },
+  { key: 'tests', title: 'Tests', types: ['test'] },
+  { key: 'maintenance', title: 'Maintenance', types: ['build', 'chore', 'ci', 'style'] },
+  { key: 'other', title: 'Other Changes', types: [] }
+];
+
+const SECTION_BY_TYPE = new Map(
+  SECTION_ORDER.flatMap((section) => section.types.map((type) => [type, section]))
+);
+
+const USAGE = [
+  'Usage: node scripts/draft-release-notes.mjs --from <ref> [--to <ref>]',
+  '',
+  'Options:',
+  '  --from <ref>   Required starting git ref/commit (exclusive)',
+  '  --to <ref>     Optional ending git ref/commit (inclusive, default: HEAD)',
+  '  --help         Show this help message'
+].join('\n');
+
+function pluralize(count, noun) {
+  return `${count} ${noun}${count === 1 ? '' : 's'}`;
+}
+
+export function parseCliArgs(argv) {
+  const options = { to: 'HEAD' };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const token = argv[index];
+
+    if (token === '--help') {
+      return { help: true };
+    }
+
+    if (token === '--from' || token === '--to') {
+      const value = argv[index + 1];
+      if (!value || value.startsWith('--')) {
+        throw new Error(`Missing value for ${token}`);
+      }
+      options[token.slice(2)] = value;
+      index += 1;
+      continue;
+    }
+
+    throw new Error(`Unknown argument: ${token}`);
+  }
+
+  if (!options.from) {
+    throw new Error('--from is required');
+  }
+
+  return options;
+}
+
+export function parseCommitHeader(subject) {
+  const trimmed = subject.trim();
+  const match = trimmed.match(/^(?<type>[a-z]+)(?:\((?<scope>[^)]+)\))?(?<breaking>!)?: (?<description>.+)$/i);
+  if (!match?.groups) {
+    return null;
+  }
+
+  return {
+    type: match.groups.type.toLowerCase(),
+    scope: match.groups.scope ?? null,
+    breaking: Boolean(match.groups.breaking),
+    description: match.groups.description.trim()
+  };
+}
+
+export function classifyCommit(commit) {
+  const parsedHeader = parseCommitHeader(commit.subject);
+  const section = parsedHeader ? (SECTION_BY_TYPE.get(parsedHeader.type) ?? SECTION_ORDER.at(-1)) : SECTION_ORDER.at(-1);
+  const hasBreakingChange = Boolean(parsedHeader?.breaking) || /(^|\n)BREAKING CHANGE:/i.test(commit.body ?? '');
+  const metadata = [];
+
+  if (parsedHeader?.scope) {
+    metadata.push(parsedHeader.scope);
+  }
+
+  if (hasBreakingChange) {
+    metadata.push('breaking');
+  }
+
+  return {
+    ...commit,
+    sectionKey: section.key,
+    sectionTitle: section.title,
+    parsedHeader,
+    title: parsedHeader?.description ?? commit.subject.trim(),
+    metadata
+  };
+}
+
+export function groupCommitsBySection(commits) {
+  const grouped = SECTION_ORDER.map((section) => ({ ...section, items: [] }));
+  const byKey = new Map(grouped.map((section) => [section.key, section]));
+
+  for (const commit of commits) {
+    const classified = classifyCommit(commit);
+    byKey.get(classified.sectionKey).items.push(classified);
+  }
+
+  return grouped.filter((section) => section.items.length > 0);
+}
+
+export function summarizeFiles(files, limit = 3) {
+  const normalized = files.filter(Boolean);
+  if (normalized.length === 0) {
+    return '';
+  }
+
+  const visible = normalized.slice(0, limit).map((filePath) => `\`${filePath}\``).join(', ');
+  const remaining = normalized.length - Math.min(normalized.length, limit);
+  return remaining > 0 ? `${visible} +${remaining} more` : visible;
+}
+
+export function renderReleaseNotes({ fromRef, toRef = 'HEAD', commits }) {
+  const groupedSections = groupCommitsBySection(commits);
+  const uniqueFiles = [...new Set(commits.flatMap((commit) => commit.files ?? []))];
+  const lines = [
+    '# Release Notes Draft',
+    '',
+    `Range: \`${fromRef}..${toRef}\``,
+    '',
+    'Summary:',
+    `- ${pluralize(commits.length, 'commit')} across ${pluralize(uniqueFiles.length, 'file')}`
+  ];
+
+  for (const section of groupedSections) {
+    lines.push(`- ${section.title}: ${section.items.length}`);
+  }
+
+  lines.push('');
+
+  if (commits.length === 0) {
+    lines.push('_No commits found in this range._');
+    return `${lines.join('\n')}\n`;
+  }
+
+  for (const section of groupedSections) {
+    lines.push(`## ${section.title}`);
+    lines.push('');
+
+    for (const commit of section.items) {
+      const metadata = commit.metadata.length > 0 ? ` _${commit.metadata.join(', ')}_` : '';
+      lines.push(`- ${commit.title} (\`${commit.shortSha}\`)${metadata}`);
+      if ((commit.files ?? []).length > 0) {
+        lines.push(`  - Files: ${summarizeFiles(commit.files)}`);
+      }
+    }
+
+    lines.push('');
+  }
+
+  return `${lines.join('\n').trimEnd()}\n`;
+}
+
+function runGit(args, { cwd = process.cwd(), execFileSyncImpl = execFileSync } = {}) {
+  try {
+    return execFileSyncImpl('git', args, {
+      cwd,
+      encoding: 'utf8'
+    }).trimEnd();
+  } catch (error) {
+    const stderr = error.stderr?.toString().trim();
+    throw new Error(stderr || error.message);
+  }
+}
+
+export function collectCommitsBetweenRefs({ fromRef, toRef = 'HEAD', cwd = process.cwd(), execFileSyncImpl = execFileSync }) {
+  const range = `${fromRef}..${toRef}`;
+  const revListOutput = runGit(['rev-list', '--reverse', range], { cwd, execFileSyncImpl });
+  const shas = revListOutput ? revListOutput.split('\n').filter(Boolean) : [];
+
+  return shas.map((sha) => {
+    const subject = runGit(['show', '-s', '--format=%s', sha], { cwd, execFileSyncImpl });
+    const body = runGit(['show', '-s', '--format=%b', sha], { cwd, execFileSyncImpl });
+    const filesOutput = runGit(['diff-tree', '--no-commit-id', '--name-only', '-r', '-m', '--root', sha], {
+      cwd,
+      execFileSyncImpl
+    });
+    const files = [...new Set(filesOutput.split('\n').map((value) => value.trim()).filter(Boolean))];
+
+    return {
+      sha,
+      shortSha: sha.slice(0, 7),
+      subject,
+      body,
+      files
+    };
+  });
+}
+
+export function draftReleaseNotes({ fromRef, toRef = 'HEAD', cwd = process.cwd(), execFileSyncImpl = execFileSync }) {
+  const commits = collectCommitsBetweenRefs({ fromRef, toRef, cwd, execFileSyncImpl });
+  return renderReleaseNotes({ fromRef, toRef, commits });
+}
+
+function isEntrypoint() {
+  if (!process.argv[1]) {
+    return false;
+  }
+
+  return import.meta.url === pathToFileURL(process.argv[1]).href;
+}
+
+if (isEntrypoint()) {
+  try {
+    const options = parseCliArgs(process.argv.slice(2));
+    if (options.help) {
+      process.stdout.write(`${USAGE}\n`);
+      process.exit(0);
+    }
+
+    process.stdout.write(draftReleaseNotes({ fromRef: options.from, toRef: options.to }));
+  } catch (error) {
+    process.stderr.write(`${error.message}\n\n${USAGE}\n`);
+    process.exit(1);
+  }
+}


### PR DESCRIPTION
## Summary

- add a local CLI to draft paste-ready release notes from git history
- add deterministic node tests for parsing, grouping, and markdown rendering
- document local usage in the README

## Verification

- `npm run test:scripts`
- `npm run test:anti-patterns`
- `npm run prepush:verify`

## Sample generated draft

```md
# Release Notes Draft

Range: `nightshift/cost-attribution-estimator..HEAD`

Summary:
- 1 commit across 4 files
- Features: 1

## Features

- add release note drafter (`affab20`) _scripts_
  - Files: `README.md`, `package.json`, `scripts/__tests__/draft-release-notes.test.mjs` +1 more
```
