### PR TITLE
fix(userscript): reject overflow transaction dates

### DIFF
--- a/apps/userscript/__tests__/formatting-helpers.test.js
+++ b/apps/userscript/__tests__/formatting-helpers.test.js
@@ -17,6 +17,9 @@ describe('formatting helpers', () => {
     assert.equal(parsed instanceof Date, true, 'valid date string should return a Date instance');
     assert.equal(parsed.getFullYear(), 2024, 'parsed year should be 2024');
     assert.equal(exports.parsePostingDate('01 Foo 2024'), null);
+    assert.equal(exports.parsePostingDate('31 Feb 2024'), null);
+    assert.equal(exports.parsePostingDate('31 Apr 2024'), null);
+    assert.equal(exports.parsePostingDate('29 Feb 2023'), null);
   });
 
   it('toISODate/fromISODate round trip', () => {
@@ -26,6 +29,10 @@ describe('formatting helpers', () => {
     const parsed = exports.fromISODate(iso);
     assert.equal(parsed instanceof Date, true, 'fromISODate should return a Date instance');
     assert.equal(parsed.getFullYear(), 2024, 'round-tripped year should be 2024');
+    assert.equal(exports.fromISODate('2024-02-31'), null);
+    assert.equal(exports.fromISODate('2024-04-31'), null);
+    assert.equal(exports.fromISODate('2023-02-29'), null);
+    assert.equal(exports.fromISODate('2024-13-01'), null);
   });
 
   it('normalizeKey and normalizeRefNo clean input', () => {

--- a/apps/userscript/__tests__/storage-flow.test.js
+++ b/apps/userscript/__tests__/storage-flow.test.js
@@ -135,6 +135,38 @@ describe('storage flows', () => {
     assert.equal(list[0].amount_value, 12);
   });
 
+  it('getStoredTransactions repairs overflow iso dates and blanks unparseable months', () => {
+    const cardSettings = {
+      defaultCategory: 'Others',
+      merchantMap: {},
+      transactions: {
+        repaired: {
+          ref_no: 'REPAIRED',
+          merchant_detail: 'Shop',
+          posting_date: '29 Feb 2024',
+          posting_date_iso: '2024-02-31',
+          amount_text: '10.00'
+        },
+        invalid: {
+          ref_no: 'INVALID',
+          merchant_detail: 'Shop',
+          posting_date: '31 Feb 2024',
+          posting_date_iso: '2024-02-31',
+          amount_text: '8.00'
+        }
+      }
+    };
+
+    const list = exports.getStoredTransactions('UOB', cardSettings);
+    const repaired = list.find((entry) => entry.ref_no === 'REPAIRED');
+    const invalid = list.find((entry) => entry.ref_no === 'INVALID');
+
+    assert.equal(repaired.posting_date_iso, '2024-02-29');
+    assert.equal(repaired.posting_month, '2024-02');
+    assert.equal(invalid.posting_date_iso, '');
+    assert.equal(invalid.posting_month, '');
+  });
+
   it('updateStoredTransactions drops stored entries with overflow iso dates', () => {
     const settings = {
       cards: {

--- a/apps/userscript/__tests__/storage-flow.test.js
+++ b/apps/userscript/__tests__/storage-flow.test.js
@@ -135,6 +135,31 @@ describe('storage flows', () => {
     assert.equal(list[0].amount_value, 12);
   });
 
+  it('updateStoredTransactions drops stored entries with overflow iso dates', () => {
+    const settings = {
+      cards: {
+        UOB: {
+          defaultCategory: 'Others',
+          merchantMap: {},
+          transactions: {
+            overflow: {
+              ref_no: 'OVERFLOW',
+              posting_date: '2024-02-31',
+              posting_date_iso: '2024-02-31',
+              amount_value: 10,
+              category: 'Dining'
+            }
+          }
+        }
+      }
+    };
+    const cardConfig = { subcapSlots: 1, categories: ['Dining'] };
+
+    exports.updateStoredTransactions(settings, 'UOB', cardConfig, []);
+
+    assert.deepEqual(settings.cards.UOB.transactions, {});
+  });
+
   it('createOverlay wires tabs and sync section replacement', () => {
     const { documentStub, elementsById } = stubDocument();
     globalThis.document = documentStub;

--- a/apps/userscript/__tests__/transactions-extended.test.js
+++ b/apps/userscript/__tests__/transactions-extended.test.js
@@ -68,4 +68,17 @@ describe('transaction parsing extended', () => {
     assert.equal(result.diagnostics.invalid_posting_date, 1);
     assert.equal(result.diagnostics.invalid_amount, 1);
   });
+
+  it('buildTransactions rejects overflow posting dates without rolling them forward', () => {
+    const cardSettings = { defaultCategory: 'Others', merchantMap: {}, transactions: {} };
+    const rows = [
+      makeRow([makeCell('31 Feb 2024'), makeCell('30 Jan 2024'), makeCell('STARBUCKS\nREF002'), makeCell('SGD 10.00')])
+    ];
+
+    const result = exports.buildTransactions(makeTbody(rows), "LADY'S SOLITAIRE CARD", cardSettings);
+
+    assert.equal(result.transactions.length, 1);
+    assert.equal(result.diagnostics.invalid_posting_date, 1);
+    assert.equal(result.transactions[0].posting_date_iso, '');
+  });
 });

--- a/apps/userscript/bank-cc-limits-subcap-calculator.user.js
+++ b/apps/userscript/bank-cc-limits-subcap-calculator.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Bank CC Limits Subcap Calculator
 // @namespace    local
-// @version      0.8.0
+// @version      0.8.1
 // @description  Extract credit card transactions and manage subcap categories with optional sync
 // @author       laurenceputra
 // @downloadURL  https://raw.githubusercontent.com/laurenceputra/sg-cc-mile-subcaps-limits-viewer/main/apps/userscript/bank-cc-limits-subcap-calculator.user.js
@@ -4620,7 +4620,7 @@
 
         const merchantDetail = normalizeText(entry.merchant_detail || '');
         const parsedDate = getParsedDate(entry);
-        const postingDateIso = entry.posting_date_iso || (parsedDate ? toISODate(parsedDate) : '');
+        const postingDateIso = parsedDate ? toISODate(parsedDate) : '';
         const amountValue =
           typeof entry.amount_value === 'number'
             ? entry.amount_value

--- a/apps/userscript/bank-cc-limits-subcap-calculator.user.js
+++ b/apps/userscript/bank-cc-limits-subcap-calculator.user.js
@@ -3998,6 +3998,21 @@
       return `${year}-${month}-${day}`;
     }
 
+    function createValidatedLocalDate(year, monthIndex, day) {
+      const date = new Date(year, monthIndex, day);
+      if (Number.isNaN(date.getTime())) {
+        return null;
+      }
+      if (
+        date.getFullYear() !== year ||
+        date.getMonth() !== monthIndex ||
+        date.getDate() !== day
+      ) {
+        return null;
+      }
+      return date;
+    }
+
     function fromISODate(value) {
       if (!value) {
         return null;
@@ -4012,8 +4027,7 @@
       if (!year || !month || !day) {
         return null;
       }
-      const date = new Date(year, month - 1, day);
-      return Number.isNaN(date.getTime()) ? null : date;
+      return createValidatedLocalDate(year, month - 1, day);
     }
 
     function parsePostingDate(value) {
@@ -4045,8 +4059,7 @@
       if (!Object.prototype.hasOwnProperty.call(monthMap, monthName)) {
         return null;
       }
-      const date = new Date(year, monthMap[monthName], day);
-      return Number.isNaN(date.getTime()) ? null : date;
+      return createValidatedLocalDate(year, monthMap[monthName], day);
     }
 
     function getCalendarCutoffDate(months) {


### PR DESCRIPTION
## Summary
- reject impossible calendar dates in `parsePostingDate()` and `fromISODate()` instead of letting JavaScript `Date` roll them into later months
- normalize persisted transaction dates through validated parsing so overflow `posting_date_iso` values no longer leak into stored transaction readers or derived `posting_month` values
- bump the userscript header version to `0.8.1` so the required version-gate passes for this userscript change

## Regression cases added
- helper rejects `31 Feb 2024`, `31 Apr 2024`, `29 Feb 2023`, `2024-02-31`, `2024-04-31`, `2023-02-29`, and `2024-13-01`
- transaction parsing increments `invalid_posting_date` for overflow dates and leaves `posting_date_iso` blank instead of silently rolling forward
- stored transaction normalization repairs overflow ISO values from valid text dates and blanks `posting_date_iso` / `posting_month` when neither stored date parses
- storage retention still drops persisted entries with overflow ISO dates during update cleanup

## Verification
- `npm run lint`
- `npm run test:userscript`
- `npm run test:anti-patterns`

## Notes
- The requested base branch `nightshift/event-taxonomy-normalizer` was not available locally or on `origin`, so the follow-up work used a clean worktree from the existing PR branch `fix/userscript-reject-overflow-dates` to avoid disturbing the dirty `main` worktree.