### PR TITLE
fix: harden sync auth and dedupe helpers

### DIFF
--- a/apps/backend/src/__tests__/workers/auth-refresh-worker.test.js
+++ b/apps/backend/src/__tests__/workers/auth-refresh-worker.test.js
@@ -28,6 +28,11 @@ function assertRefreshCookieSecurity(setCookieHeader, label) {
   assert.match(setCookieHeader, /SameSite=Strict/i, `${label}: cookie enforces strict same-site policy`);
 }
 
+function decodeJwtPayload(token) {
+  const payload = token.split('.')[1].replace(/-/g, '+').replace(/_/g, '/');
+  return JSON.parse(Buffer.from(payload, 'base64').toString('utf8'));
+}
+
 async function registerUser(env, email, passwordHash) {
   return fetchJson(app, env, '/auth/register', {
     method: 'POST',
@@ -103,6 +108,113 @@ describe('Workers auth refresh flow', () => {
     }
   });
 
+  test('recent rotation replay does not revoke the winning token family', async () => {
+    const { mf, db } = await createTestDatabase();
+    try {
+      const env = { ...createTestEnv(), db };
+      const email = randomEmail();
+      const passwordHash = crypto.randomBytes(32).toString('hex');
+
+      await registerUser(env, email, passwordHash);
+      const { response: loginRes } = await loginUser(env, email, passwordHash);
+      const originalRefreshToken = extractCookieValue(loginRes.headers.get('Set-Cookie'), 'ccSubcapRefreshToken');
+      assert.ok(originalRefreshToken);
+
+      const originalHash = crypto.createHash('sha256').update(originalRefreshToken).digest('hex');
+      const originalRecord = await db.getRefreshTokenByHash(originalHash);
+      assert.ok(originalRecord);
+
+      const rotated = await db.markRefreshTokenRotated(originalRecord.id, 'already-claimed');
+      assert.equal(rotated, 1);
+      const winnerRefreshToken = 'winner-token';
+      const childId = await db.createRefreshToken(
+        originalRecord.user_id,
+        crypto.createHash('sha256').update(winnerRefreshToken).digest('hex'),
+        originalRecord.family_id,
+        Math.floor(Date.now() / 1000) + 3600,
+        originalRecord.id
+      );
+      assert.ok(childId);
+
+      const raceRes = await app.fetch(new Request('http://localhost/auth/refresh', {
+        method: 'POST',
+        headers: {
+          'Origin': 'https://pib.uob.com.sg',
+          'Cookie': `ccSubcapRefreshToken=${originalRefreshToken}`
+        }
+      }), env);
+      assert.equal(raceRes.status, 401);
+
+      const familyRows = await db.all('SELECT revoked_at FROM refresh_tokens WHERE family_id = ?', originalRecord.family_id);
+      assert.equal(familyRows.every((row) => row.revoked_at === null), true);
+
+      const winnerRes = await app.fetch(new Request('http://localhost/auth/refresh', {
+        method: 'POST',
+        headers: {
+          'Origin': 'https://pib.uob.com.sg',
+          'Cookie': `ccSubcapRefreshToken=${winnerRefreshToken}`
+        }
+      }), env);
+      assert.equal(winnerRes.status, 200);
+    } finally {
+      await disposeTestDatabase(mf);
+    }
+  });
+
+  test('older rotated token reuse revokes the token family', async () => {
+    const { mf, db } = await createTestDatabase();
+    try {
+      const env = { ...createTestEnv(), db };
+      const email = randomEmail();
+      const passwordHash = crypto.randomBytes(32).toString('hex');
+
+      await registerUser(env, email, passwordHash);
+      const { response: loginRes } = await loginUser(env, email, passwordHash);
+      const originalRefreshToken = extractCookieValue(loginRes.headers.get('Set-Cookie'), 'ccSubcapRefreshToken');
+      const originalHash = crypto.createHash('sha256').update(originalRefreshToken).digest('hex');
+      const originalRecord = await db.getRefreshTokenByHash(originalHash);
+      assert.ok(originalRecord);
+
+      await db.markRefreshTokenRotated(originalRecord.id, 'old-rotation');
+      const childRefreshToken = 'child-after-old-rotation';
+      await db.createRefreshToken(
+        originalRecord.user_id,
+        crypto.createHash('sha256').update(childRefreshToken).digest('hex'),
+        originalRecord.family_id,
+        Math.floor(Date.now() / 1000) + 3600,
+        originalRecord.id
+      );
+      await db.run(
+        'UPDATE refresh_tokens SET rotated_at = ? WHERE id = ?',
+        Math.floor(Date.now() / 1000) - 60,
+        originalRecord.id
+      );
+
+      const reuseRes = await app.fetch(new Request('http://localhost/auth/refresh', {
+        method: 'POST',
+        headers: {
+          'Origin': 'https://pib.uob.com.sg',
+          'Cookie': `ccSubcapRefreshToken=${originalRefreshToken}`
+        }
+      }), env);
+      assert.equal(reuseRes.status, 401);
+
+      const familyRows = await db.all('SELECT revoked_at FROM refresh_tokens WHERE family_id = ?', originalRecord.family_id);
+      assert.equal(familyRows.every((row) => row.revoked_at !== null), true);
+
+      const childRes = await app.fetch(new Request('http://localhost/auth/refresh', {
+        method: 'POST',
+        headers: {
+          'Origin': 'https://pib.uob.com.sg',
+          'Cookie': `ccSubcapRefreshToken=${childRefreshToken}`
+        }
+      }), env);
+      assert.equal(childRes.status, 401);
+    } finally {
+      await disposeTestDatabase(mf);
+    }
+  });
+
   test('logout clears refresh cookie', async () => {
     const { mf, db } = await createTestDatabase();
     try {
@@ -129,6 +241,70 @@ describe('Workers auth refresh flow', () => {
       const logoutCookie = logoutRes.headers.get('Set-Cookie');
       assert.ok(logoutCookie);
       assert.ok(logoutCookie.includes('Max-Age=0'));
+    } finally {
+      await disposeTestDatabase(mf);
+    }
+  });
+
+  test('single logout does not revoke another active access token for the same user', async () => {
+    const { mf, db } = await createTestDatabase();
+    try {
+      const env = { ...createTestEnv(), db };
+      const email = randomEmail();
+      const passwordHash = crypto.randomBytes(32).toString('hex');
+
+      await registerUser(env, email, passwordHash);
+      const { response: firstLoginRes, json: firstLoginData } = await loginUser(env, email, passwordHash);
+      const { json: secondLoginData } = await loginUser(env, email, passwordHash);
+      const firstRefreshToken = extractCookieValue(firstLoginRes.headers.get('Set-Cookie'), 'ccSubcapRefreshToken');
+
+      const logoutRes = await app.fetch(new Request('http://localhost/auth/logout', {
+        method: 'POST',
+        headers: {
+          'Authorization': `Bearer ${firstLoginData.token}`,
+          'Origin': 'https://pib.uob.com.sg',
+          'Cookie': `ccSubcapRefreshToken=${firstRefreshToken}`
+        }
+      }), env);
+      assert.equal(logoutRes.status, 200);
+
+      const loggedOutTokenRes = await app.fetch(new Request('http://localhost/sync/data', {
+        method: 'GET',
+        headers: { Authorization: `Bearer ${firstLoginData.token}` }
+      }), env);
+      assert.equal(loggedOutTokenRes.status, 401);
+
+      const secondTokenRes = await app.fetch(new Request('http://localhost/sync/data', {
+        method: 'GET',
+        headers: { Authorization: `Bearer ${secondLoginData.token}` }
+      }), env);
+      assert.equal(secondTokenRes.status, 200);
+    } finally {
+      await disposeTestDatabase(mf);
+    }
+  });
+
+  test('logout_all marker revokes previously issued access tokens', async () => {
+    const { mf, db } = await createTestDatabase();
+    try {
+      const env = { ...createTestEnv(), db };
+      const email = randomEmail();
+      const passwordHash = crypto.randomBytes(32).toString('hex');
+
+      await registerUser(env, email, passwordHash);
+      const { json: loginData } = await loginUser(env, email, passwordHash);
+      const payload = decodeJwtPayload(loginData.token);
+      await db.blacklistToken(payload.userId, 'logout-all-marker', Math.floor(Date.now() / 1000) + 3600, 'logout_all');
+      await db.run(
+        "UPDATE token_blacklist SET blacklisted_at = ? WHERE token_jti = 'logout-all-marker'",
+        payload.iat + 1
+      );
+
+      const res = await app.fetch(new Request('http://localhost/sync/data', {
+        method: 'GET',
+        headers: { Authorization: `Bearer ${loginData.token}` }
+      }), env);
+      assert.equal(res.status, 401);
     } finally {
       await disposeTestDatabase(mf);
     }

--- a/apps/backend/src/__tests__/workers/security-worker.test.js
+++ b/apps/backend/src/__tests__/workers/security-worker.test.js
@@ -154,4 +154,25 @@ describe('Workers security basics', () => {
       await disposeTestDatabase(mf);
     }
   });
+
+  test('rejects oversized JSON before parsing invalid JSON', async () => {
+    const { mf, db } = await createTestDatabase();
+    try {
+      const env = { ...createTestEnv({ ENVIRONMENT: 'production', NODE_ENV: 'production' }), db };
+      const res = await app.fetch(new Request('http://localhost/auth/register', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-CC-Userscript': 'tampermonkey-v1'
+        },
+        body: `{"email":"${'x'.repeat(1024 * 1024)}"`
+      }), env);
+
+      assert.equal(res.status, 413);
+      const data = await res.json();
+      assert.equal(data.error, 'Request payload too large');
+    } finally {
+      await disposeTestDatabase(mf);
+    }
+  });
 });

--- a/apps/backend/src/__tests__/workers/validation-utils.test.js
+++ b/apps/backend/src/__tests__/workers/validation-utils.test.js
@@ -1,6 +1,7 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import { normalizeEmail, isDisposableEmail, validateInput, sanitizeString } from '../../middleware/validation.js';
+import { isPayloadTooLarge, readRequestBodyWithLimit } from '../../middleware/payload-size.js';
 
 describe('validation utils', () => {
   it('normalizes emails and blocks disposable domains', () => {
@@ -21,5 +22,32 @@ describe('validation utils', () => {
   it('sanitizes control characters and trims', () => {
     const result = sanitizeString('  hello\u0000world  ');
     assert.equal(result, 'helloworld');
+  });
+
+  it('detects oversized payloads without relying on content-length', async () => {
+    const oversized = new Request('http://localhost/test', {
+      method: 'POST',
+      body: 'x'.repeat(11)
+    });
+    assert.equal(await isPayloadTooLarge(oversized, 10), true);
+  });
+
+  it('allows payloads at the configured size boundary', async () => {
+    const boundary = new Request('http://localhost/test', {
+      method: 'POST',
+      body: 'x'.repeat(10)
+    });
+    assert.equal(await isPayloadTooLarge(boundary, 10), false);
+  });
+
+  it('returns bounded body text for allowed payloads', async () => {
+    const request = new Request('http://localhost/test', {
+      method: 'POST',
+      body: '{"ok":true}'
+    });
+    assert.deepEqual(await readRequestBodyWithLimit(request, 20), {
+      tooLarge: false,
+      text: '{"ok":true}'
+    });
   });
 });

--- a/apps/backend/src/api/auth.js
+++ b/apps/backend/src/api/auth.js
@@ -9,6 +9,7 @@ const ACCESS_TOKEN_TTL_SECONDS_DEFAULT = 60 * 60;
 const ACCESS_TOKEN_TTL_SECONDS_MIN = 15 * 60;
 const ACCESS_TOKEN_TTL_SECONDS_MAX = 24 * 60 * 60;
 const REFRESH_TOKEN_TTL_SECONDS = 30 * 24 * 60 * 60;
+const REFRESH_ROTATION_RACE_GRACE_SECONDS = 5;
 const REFRESH_COOKIE_NAME = 'ccSubcapRefreshToken';
 const REFRESH_COOKIE_PATH = '/auth';
 
@@ -217,6 +218,15 @@ export default function createAuthRoutes(rateLimiters) {
         return c.json({ error: 'Unauthorized' }, 401);
       }
       if (tokenRecord.replaced_by) {
+        if (tokenRecord.rotated_at && now - tokenRecord.rotated_at <= REFRESH_ROTATION_RACE_GRACE_SECONDS) {
+          await logAuditEvent(db, {
+            eventType: AuditEventType.REFRESH_TOKEN_REUSE,
+            request: c.req.raw,
+            userId: tokenRecord.user_id,
+            details: { familyId: tokenRecord.family_id, reason: 'rotation_race' }
+          });
+          return c.json({ error: 'Unauthorized' }, 401);
+        }
         await logAuditEvent(db, {
           eventType: AuditEventType.REFRESH_TOKEN_REUSE,
           request: c.req.raw,
@@ -234,16 +244,20 @@ export default function createAuthRoutes(rateLimiters) {
       const newRefreshToken = generateOpaqueToken();
       const newRefreshTokenHash = await hashRefreshToken(newRefreshToken);
       const expiresAt = now + REFRESH_TOKEN_TTL_SECONDS;
-      await db.createRefreshToken(tokenRecord.user_id, newRefreshTokenHash, tokenRecord.family_id, expiresAt, tokenRecord.id);
-      const rotated = await db.markRefreshTokenRotated(tokenRecord.id, newRefreshTokenHash);
-      if (rotated === 0) {
+      const newRefreshTokenId = await db.rotateRefreshToken(
+        tokenRecord.id,
+        tokenRecord.user_id,
+        newRefreshTokenHash,
+        tokenRecord.family_id,
+        expiresAt
+      );
+      if (!newRefreshTokenId) {
         await logAuditEvent(db, {
           eventType: AuditEventType.REFRESH_TOKEN_REUSE,
           request: c.req.raw,
           userId: tokenRecord.user_id,
           details: { familyId: tokenRecord.family_id, reason: 'race' }
         });
-        await db.revokeRefreshTokenFamily(tokenRecord.family_id, 'reuse_detected');
         return c.json({ error: 'Unauthorized' }, 401);
       }
 

--- a/apps/backend/src/api/web.js
+++ b/apps/backend/src/api/web.js
@@ -1,43 +1,8 @@
 import { Hono } from 'hono';
+import { CARD_NAME, CAP_POLICY, INACTIVITY_TTL_MS, STORAGE_KEYS, VAULT_CONFIG } from './web/constants.js';
+import { createNonce, htmlResponse, renderPage } from './web/page.js';
 
 const web = new Hono();
-
-const CARD_NAME = "LADY'S SOLITAIRE CARD";
-const CAP_POLICY = Object.freeze({
-  version: 1,
-  thresholds: {
-    warningRatio: 0.9333333333,
-    criticalRatio: 1
-  },
-  styles: {
-    normal: { background: '#f1f5f9', border: '#cbd5e1', text: '#334155' },
-    warning: { background: '#fef3c7', border: '#f59e0b', text: '#92400e' },
-    critical: { background: '#fee2e2', border: '#ef4444', text: '#991b1b' }
-  },
-  cards: {
-    "LADY'S SOLITAIRE CARD": {
-      mode: 'per-category',
-      cap: 750
-    },
-    'XL Rewards Card': {
-      mode: 'combined',
-      cap: 1000
-    }
-  }
-});
-const INACTIVITY_TTL_MS = 30 * 24 * 60 * 60 * 1000;
-const STORAGE_KEYS = {
-  token: 'ccSubcapSyncToken',
-  email: 'ccSubcapSyncEmail',
-  lastActiveAt: 'ccSubcapSyncLastActiveAt',
-  legacyPassphrase: 'ccSubcapSyncPassphrase',
-  legacyLastLoginAt: 'ccSubcapSyncLastLoginAt'
-};
-const VAULT_CONFIG = {
-  dbName: 'ccSubcapWebVault',
-  storeName: 'syncKeys',
-  recordId: 'sync-key-v1'
-};
 
 const BASE_STYLES = `
   :root {
@@ -225,49 +190,8 @@ const BASE_STYLES = `
   }
 `;
 
-function createNonce() {
-  const bytes = crypto.getRandomValues(new Uint8Array(16));
-  return Array.from(bytes).map(byte => byte.toString(16).padStart(2, '0')).join('');
-}
-
-function buildCsp(nonce) {
-  const cspDirectives = [
-    "default-src 'none'",
-    `script-src 'nonce-${nonce}'`,
-    "style-src 'self' 'unsafe-inline'",
-    "img-src 'self' data:",
-    "connect-src 'self'",
-    "base-uri 'self'",
-    "form-action 'self'",
-    "frame-ancestors 'none'"
-  ];
-  return cspDirectives.join('; ');
-}
-
-function renderPage({ title, body, script, nonce }) {
-  return `<!doctype html>
-<html lang="en">
-  <head>
-    <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>${title}</title>
-    <style>${BASE_STYLES}</style>
-  </head>
-  <body>
-    ${body}
-    <script nonce="${nonce}">
-      ${script}
-    </script>
-  </body>
-</html>`;
-}
-
-function htmlResponse(c, html, nonce) {
-  return c.text(html, 200, {
-    'Content-Type': 'text/html; charset=utf-8',
-    'Cache-Control': 'no-store',
-    'Content-Security-Policy': buildCsp(nonce)
-  });
+function renderWebPage(options) {
+  return renderPage({ ...options, styles: BASE_STYLES });
 }
 
 web.get('/login', (c) => {
@@ -555,7 +479,7 @@ web.get('/login', (c) => {
     })();
   `;
 
-  return htmlResponse(c, renderPage({ title: 'Sync Login', body, script, nonce }), nonce);
+  return htmlResponse(c, renderWebPage({ title: 'Sync Login', body, script, nonce }), nonce);
 });
 
 web.get('/meta/cap-policy', (c) => {
@@ -1221,7 +1145,7 @@ web.get('/dashboard', (c) => {
     })();
   `;
 
-  return htmlResponse(c, renderPage({ title: 'Sync Dashboard', body, script, nonce }), nonce);
+  return htmlResponse(c, renderWebPage({ title: 'Sync Dashboard', body, script, nonce }), nonce);
 });
 
 export default web;

--- a/apps/backend/src/api/web/constants.js
+++ b/apps/backend/src/api/web/constants.js
@@ -1,0 +1,40 @@
+export const CARD_NAME = "LADY'S SOLITAIRE CARD";
+
+export const CAP_POLICY = Object.freeze({
+  version: 1,
+  thresholds: {
+    warningRatio: 0.9333333333,
+    criticalRatio: 1
+  },
+  styles: {
+    normal: { background: '#f1f5f9', border: '#cbd5e1', text: '#334155' },
+    warning: { background: '#fef3c7', border: '#f59e0b', text: '#92400e' },
+    critical: { background: '#fee2e2', border: '#ef4444', text: '#991b1b' }
+  },
+  cards: {
+    "LADY'S SOLITAIRE CARD": {
+      mode: 'per-category',
+      cap: 750
+    },
+    'XL Rewards Card': {
+      mode: 'combined',
+      cap: 1000
+    }
+  }
+});
+
+export const INACTIVITY_TTL_MS = 30 * 24 * 60 * 60 * 1000;
+
+export const STORAGE_KEYS = {
+  token: 'ccSubcapSyncToken',
+  email: 'ccSubcapSyncEmail',
+  lastActiveAt: 'ccSubcapSyncLastActiveAt',
+  legacyPassphrase: 'ccSubcapSyncPassphrase',
+  legacyLastLoginAt: 'ccSubcapSyncLastLoginAt'
+};
+
+export const VAULT_CONFIG = {
+  dbName: 'ccSubcapWebVault',
+  storeName: 'syncKeys',
+  recordId: 'sync-key-v1'
+};

--- a/apps/backend/src/api/web/page.js
+++ b/apps/backend/src/api/web/page.js
@@ -1,0 +1,44 @@
+export function createNonce() {
+  const bytes = crypto.getRandomValues(new Uint8Array(16));
+  return Array.from(bytes).map(byte => byte.toString(16).padStart(2, '0')).join('');
+}
+
+export function buildCsp(nonce) {
+  const cspDirectives = [
+    "default-src 'none'",
+    `script-src 'nonce-${nonce}'`,
+    "style-src 'self' 'unsafe-inline'",
+    "img-src 'self' data:",
+    "connect-src 'self'",
+    "base-uri 'self'",
+    "form-action 'self'",
+    "frame-ancestors 'none'"
+  ];
+  return cspDirectives.join('; ');
+}
+
+export function renderPage({ title, body, script, nonce, styles }) {
+  return `<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>${title}</title>
+    <style>${styles}</style>
+  </head>
+  <body>
+    ${body}
+    <script nonce="${nonce}">
+      ${script}
+    </script>
+  </body>
+</html>`;
+}
+
+export function htmlResponse(c, html, nonce) {
+  return c.text(html, 200, {
+    'Content-Type': 'text/html; charset=utf-8',
+    'Cache-Control': 'no-store',
+    'Content-Security-Policy': buildCsp(nonce)
+  });
+}

--- a/apps/backend/src/app.js
+++ b/apps/backend/src/app.js
@@ -62,11 +62,11 @@ export function createApp(rateLimiters) {
     })(c, next);
   });
 
-  // JSON validation middleware
-  app.use('/*', validateJsonMiddleware());
-
   // Global payload size limit
   app.use('/*', rateLimiters.payloadSizeLimitMiddleware());
+
+  // JSON validation middleware
+  app.use('/*', validateJsonMiddleware());
 
   // Health check
   app.get('/', (c) => c.json({ status: 'ok', service: 'bank-cc-sync' }));

--- a/apps/backend/src/middleware/payload-size.js
+++ b/apps/backend/src/middleware/payload-size.js
@@ -1,0 +1,61 @@
+import { rateLimitConfig } from './rate-limit-config.js';
+
+export function payloadTooLargeResponse(c) {
+  return c.json({
+    error: rateLimitConfig.payloadSizeLimit.errorMessage,
+    maxSize: `${rateLimitConfig.payloadSizeLimit.maxBytes / 1024 / 1024}MB`
+  }, 413);
+}
+
+export async function readRequestBodyWithLimit(request, maxBytes = rateLimitConfig.payloadSizeLimit.maxBytes) {
+  const contentLength = request.headers.get('Content-Length');
+  if (contentLength) {
+    const size = Number.parseInt(contentLength, 10);
+    if (Number.isFinite(size) && size > maxBytes) {
+      return { tooLarge: true, text: '' };
+    }
+  }
+
+  if (!request.body) {
+    return { tooLarge: false, text: '' };
+  }
+
+  const reader = request.body.getReader();
+  const decoder = new TextDecoder();
+  let total = 0;
+  let text = '';
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) {
+        text += decoder.decode();
+        return { tooLarge: false, text };
+      }
+      total += value?.byteLength || 0;
+      if (total > maxBytes) {
+        await reader.cancel();
+        return { tooLarge: true, text: '' };
+      }
+      text += decoder.decode(value, { stream: true });
+    }
+  } finally {
+    reader.releaseLock();
+  }
+}
+
+export async function isPayloadTooLarge(request, maxBytes = rateLimitConfig.payloadSizeLimit.maxBytes) {
+  const result = await readRequestBodyWithLimit(request, maxBytes);
+  return result.tooLarge;
+}
+
+export function payloadSizeLimitMiddleware() {
+  return async (c, next) => {
+    const result = await readRequestBodyWithLimit(c.req.raw);
+    if (result.tooLarge) {
+      return payloadTooLargeResponse(c);
+    }
+    c.set('rawBodyText', result.text);
+
+    await next();
+  };
+}

--- a/apps/backend/src/middleware/rate-limiter.js
+++ b/apps/backend/src/middleware/rate-limiter.js
@@ -1,27 +1,9 @@
-import { rateLimitConfig } from './rate-limit-config.js';
 import {
   createRateLimiter,
   progressiveDelayMiddleware
 } from './rate-limiter-worker.js';
-
-export function payloadSizeLimitMiddleware() {
-  return async (c, next) => {
-    const contentLength = c.req.header('Content-Length');
-
-    if (contentLength) {
-      const size = parseInt(contentLength, 10);
-
-      if (size > rateLimitConfig.payloadSizeLimit.maxBytes) {
-        return c.json({
-          error: rateLimitConfig.payloadSizeLimit.errorMessage,
-          maxSize: `${rateLimitConfig.payloadSizeLimit.maxBytes / 1024 / 1024}MB`
-        }, 413);
-      }
-    }
-
-    await next();
-  };
-}
+import { rateLimitConfig } from './rate-limit-config.js';
+export { payloadSizeLimitMiddleware } from './payload-size.js';
 
 export { progressiveDelayMiddleware };
 

--- a/apps/backend/src/middleware/validation.js
+++ b/apps/backend/src/middleware/validation.js
@@ -7,7 +7,6 @@
  * - Data integrity issues
  */
 
-import { rateLimitConfig } from './rate-limit-config.js';
 
 // RFC 5321 compliant email regex (simplified but practical)
 const EMAIL_REGEX = /^[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$/;
@@ -336,18 +335,12 @@ export function validateJsonMiddleware() {
     
     // Try to parse JSON
     try {
-      const contentLength = c.req.header('Content-Length');
-      if (contentType && contentLength && parseInt(contentLength, 10) > rateLimitConfig.payloadSizeLimit.maxBytes) {
-        return c.json({ 
-          error: rateLimitConfig.payloadSizeLimit.errorMessage,
-          maxSize: `${rateLimitConfig.payloadSizeLimit.maxBytes / 1024 / 1024}MB`
-        }, 413);
-      }
       if (method === 'DELETE' && (!contentType || c.req.header('Content-Length') === '0')) {
         return next();
       }
 
-      const body = await c.req.json();
+      const rawBodyText = c.get('rawBodyText');
+      const body = typeof rawBodyText === 'string' ? JSON.parse(rawBodyText) : await c.req.json();
       
       // Check for excessive nesting (DoS prevention)
       const maxDepth = 10;

--- a/apps/backend/src/storage/db.js
+++ b/apps/backend/src/storage/db.js
@@ -138,6 +138,40 @@ export class Database {
     return result?.meta?.changes ?? 0;
   }
 
+  async rotateRefreshToken(id, userId, tokenHash, familyId, expiresAt) {
+    if (typeof this.db.batch === 'function') {
+      const results = await this.db.batch([
+        this.db.prepare(`
+          UPDATE refresh_tokens
+          SET replaced_by = ?, rotated_at = strftime('%s', 'now')
+          WHERE id = ? AND replaced_by IS NULL AND revoked_at IS NULL
+        `).bind(tokenHash, id),
+        this.db.prepare(`
+          INSERT INTO refresh_tokens (
+            user_id,
+            token_hash,
+            family_id,
+            parent_id,
+            expires_at
+          )
+          SELECT ?, ?, ?, ?, ?
+          WHERE EXISTS (
+            SELECT 1 FROM refresh_tokens
+            WHERE id = ? AND replaced_by = ? AND revoked_at IS NULL
+          )
+        `).bind(userId, tokenHash, familyId, id, expiresAt, id, tokenHash)
+      ]);
+      const inserted = results?.[1]?.meta?.changes ?? 0;
+      return inserted > 0 ? Number(results?.[1]?.meta?.last_row_id) : null;
+    }
+
+    const rotated = await this.markRefreshTokenRotated(id, tokenHash);
+    if (rotated === 0) {
+      return null;
+    }
+    return this.createRefreshToken(userId, tokenHash, familyId, expiresAt, id);
+  }
+
   async revokeRefreshToken(id, reason = 'revoked') {
     await this.run(
       `
@@ -176,7 +210,7 @@ export class Database {
 
   async getUserBlacklistTimestamp(userId) {
     const result = await this.first(
-      'SELECT MAX(blacklisted_at) as timestamp FROM token_blacklist WHERE user_id = ?',
+      "SELECT MAX(blacklisted_at) as timestamp FROM token_blacklist WHERE user_id = ? AND reason = 'logout_all'",
       userId
     );
     return result?.timestamp || 0;

--- a/apps/userscript/__tests__/coverage-helpers-extended.test.js
+++ b/apps/userscript/__tests__/coverage-helpers-extended.test.js
@@ -80,7 +80,13 @@ describe('coverage helpers extended', () => {
     assert.throws(() => exports.validateServerUrl(''), /required/);
     assert.throws(() => exports.validateServerUrl('not-a-url'), /Invalid URL/);
     assert.throws(() => exports.validateServerUrl('ftp://example.com'), /HTTP or HTTPS/);
+    assert.throws(() => exports.validateServerUrl('http://example.com'), /HTTPS unless/);
+    assert.throws(() => exports.validateServerUrl('http://192.168.0.1:8787'), /HTTPS unless/);
     assert.doesNotThrow(() => exports.validateServerUrl('https://example.com'));
+    assert.doesNotThrow(() => exports.validateServerUrl('https://bank-cc-sync.laurenceputra.workers.dev'));
+    assert.doesNotThrow(() => exports.validateServerUrl('http://localhost:8787'));
+    assert.doesNotThrow(() => exports.validateServerUrl('http://127.0.0.1:8787'));
+    assert.doesNotThrow(() => exports.validateServerUrl('http://[::1]:8787'));
   });
 
 

--- a/apps/userscript/__tests__/helpers/test-doubles.js
+++ b/apps/userscript/__tests__/helpers/test-doubles.js
@@ -71,3 +71,28 @@ export function makeCryptoManager() {
     }
   };
 }
+
+export function makeSyncApiClient(overrides = {}) {
+  return {
+    token: null,
+    setToken(token) { this.token = token; },
+    async getSyncData() { return overrides.getSyncData ? overrides.getSyncData() : null; },
+    async putSyncData(data, version) {
+      return overrides.putSyncData ? overrides.putSyncData(data, version) : { version };
+    }
+  };
+}
+
+export function makeSyncCrypto(overrides = {}) {
+  return {
+    async decrypt(ciphertext, iv, salt) {
+      if (overrides.decrypt) return overrides.decrypt(ciphertext, iv, salt);
+      return JSON.parse(Buffer.from(ciphertext, 'base64').toString('utf8'));
+    },
+    async encrypt(payload) {
+      if (overrides.encrypt) return overrides.encrypt(payload);
+      const encoded = Buffer.from(JSON.stringify(payload), 'utf8').toString('base64');
+      return { ciphertext: encoded, iv: 'test-iv', salt: 'test-salt' };
+    }
+  };
+}

--- a/apps/userscript/__tests__/storage-flow.test.js
+++ b/apps/userscript/__tests__/storage-flow.test.js
@@ -79,6 +79,28 @@ describe('storage flows', () => {
     assert.equal(cardSettings.defaultCategory, 'Others');
   });
 
+  it('applyCardSettingsToLocalStore persists normalized card settings', () => {
+    const store = new Map();
+    globalThis.GM_getValue = (key, fallback) => store.has(key) ? store.get(key) : fallback;
+    globalThis.GM_setValue = (key, value) => { store.set(key, value); };
+    globalThis.GM_deleteValue = (key) => { store.delete(key); };
+
+    const applied = exports.applyCardSettingsToLocalStore('XL Rewards Card', {
+      selectedCategories: ['Local', 'Forex', 'Ignored extra'],
+      defaultCategory: 'Forex',
+      merchantMap: { SHOP: 'Local' },
+      monthlyTotals: { '2026-01': { totals: { Local: 12 }, total_amount: 12 } }
+    });
+
+    assert.equal(applied, true);
+    const stored = JSON.parse(store.get('ccSubcapSettings'));
+    const card = stored.cards['XL Rewards Card'];
+    assert.deepEqual(card.selectedCategories, ['Local', 'Forex']);
+    assert.equal(card.defaultCategory, 'Forex');
+    assert.deepEqual(card.merchantMap, { SHOP: 'Local' });
+    assert.deepEqual(card.monthlyTotals, { '2026-01': { totals: { Local: 12 }, total_amount: 12 } });
+  });
+
   it('updateStoredTransactions keeps only in-cutoff entries', () => {
     const settings = { cards: {} };
     const cardConfig = { subcapSlots: 1, categories: ['Dining'] };

--- a/apps/userscript/__tests__/sync-engine.test.js
+++ b/apps/userscript/__tests__/sync-engine.test.js
@@ -1,35 +1,10 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import { loadExports, normalizeValue } from './helpers/load-userscript-exports.js';
-import { makeMemoryStorage } from './helpers/test-doubles.js';
+import { makeMemoryStorage, makeSyncApiClient, makeSyncCrypto } from './helpers/test-doubles.js';
 
-// ── helpers ──────────────────────────────────────────────────────────────────
-
-function makeApiClient(overrides = {}) {
-  return {
-    token: null,
-    setToken(t) { this.token = t; },
-    async getSyncData() { return overrides.getSyncData ? overrides.getSyncData() : null; },
-    async putSyncData(data, version) {
-      return overrides.putSyncData ? overrides.putSyncData(data, version) : { version };
-    }
-  };
-}
-
-function makeCrypto(overrides = {}) {
-  return {
-    async decrypt(ciphertext, iv, salt) {
-      if (overrides.decrypt) return overrides.decrypt(ciphertext, iv, salt);
-      // Passthrough: ciphertext is a JSON-stringified object encoded as base64 → return parsed object
-      return JSON.parse(Buffer.from(ciphertext, 'base64').toString('utf8'));
-    },
-    async encrypt(payload) {
-      if (overrides.encrypt) return overrides.encrypt(payload);
-      const encoded = Buffer.from(JSON.stringify(payload), 'utf8').toString('base64');
-      return { ciphertext: encoded, iv: 'test-iv', salt: 'test-salt' };
-    }
-  };
-}
+const makeApiClient = makeSyncApiClient;
+const makeCrypto = makeSyncCrypto;
 
 // ── tests ─────────────────────────────────────────────────────────────────────
 

--- a/apps/userscript/bank-cc-limits-subcap-calculator.user.js
+++ b/apps/userscript/bank-cc-limits-subcap-calculator.user.js
@@ -11,24 +11,23 @@
 // @run-at       document-idle
 // @grant        GM_getValue
 // @grant        GM_setValue
+// @grant        GM_deleteValue
 // @grant        GM_addStyle
 // @grant        GM_xmlhttpRequest
 // @connect      bank-cc-sync.laurenceputra.workers.dev
 // @connect      laurenceputra.workers.dev
 // @connect      localhost
+// @connect      127.0.0.1
+// @connect      ::1
 // ==/UserScript==
 
 (function () {
   'use strict';
 
   class StorageAdapter {
-    constructor() {
-      this.useGM = typeof GM_getValue === 'function' && typeof GM_setValue === 'function';
-    }
-
     get(key, fallback = null) {
       try {
-        if (this.useGM) {
+        if (typeof GM_getValue === 'function') {
           return GM_getValue(key, fallback);
         }
       } catch (error) {
@@ -40,7 +39,7 @@
 
     set(key, value) {
       try {
-        if (this.useGM) {
+        if (typeof GM_setValue === 'function') {
           GM_setValue(key, value);
           return;
         }
@@ -52,7 +51,7 @@
 
     remove(key) {
       try {
-        if (this.useGM && typeof GM_deleteValue === 'function') {
+        if (typeof GM_deleteValue === 'function') {
           GM_deleteValue(key);
           return;
         }
@@ -369,9 +368,17 @@
       throw new Error('Invalid URL format');
     }
 
-    const allowedProtocols = ['http:', 'https:'];
-    if (!allowedProtocols.includes(parsed.protocol)) {
+    if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
       throw new Error('Server URL must use HTTP or HTTPS protocol');
+    }
+
+    const isLocalHttpHost =
+      parsed.hostname === 'localhost' ||
+      parsed.hostname === '127.0.0.1' ||
+      parsed.hostname === '[::1]' ||
+      parsed.hostname === '::1';
+    if (parsed.protocol === 'http:' && !isLocalHttpHost) {
+      throw new Error('Server URL must use HTTPS unless it is localhost or loopback');
     }
   }
 
@@ -2434,10 +2441,10 @@
     return Number.isFinite(date.getTime()) ? date.toLocaleString() : fallback;
   }
 
-  function formatMonthKeyForDisplay(monthKey) {
+  function formatMonthKeyForDisplay(monthKey, fallback = '-') {
     const match = String(monthKey || '').match(/^(\d{4})-(\d{2})$/);
     if (!match) {
-      return String(monthKey || '-');
+      return String(monthKey || fallback);
     }
     const monthNames = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
     const monthIndex = Number(match[2]) - 1;
@@ -2655,13 +2662,7 @@
         : 'Others';
 
     (Array.isArray(transactions) ? transactions : []).forEach((transaction) => {
-      const monthKey = typeof transaction?.posting_month === 'string'
-        ? transaction.posting_month
-        : (
-            typeof transaction?.posting_date_iso === 'string' && transaction.posting_date_iso.length >= 7
-              ? transaction.posting_date_iso.slice(0, 7)
-              : ''
-          );
+      const monthKey = getTransactionMonthKey(transaction);
       if (!monthKey) {
         return;
       }
@@ -2681,6 +2682,16 @@
     });
 
     return totalsByMonth;
+  }
+
+  function getTransactionMonthKey(transaction) {
+    return typeof transaction?.posting_month === 'string' && transaction.posting_month
+      ? transaction.posting_month
+      : (
+          typeof transaction?.posting_date_iso === 'string' && transaction.posting_date_iso.length >= 7
+            ? transaction.posting_date_iso.slice(0, 7)
+            : ''
+        );
   }
 
   function buildSyncCardSnapshot(cardName, cardSettings, storedTransactions) {
@@ -3669,30 +3680,7 @@
       return fromISODate(entry.posting_date_iso) || parsePostingDate(entry.posting_date);
     }
 
-    const storage = {
-      get(key, fallback) {
-        try {
-          if (typeof GM_getValue === 'function') {
-            return GM_getValue(key, fallback);
-          }
-        } catch (error) {
-          // ignore
-        }
-        const stored = window.localStorage.getItem(key);
-        return stored ?? fallback;
-      },
-      set(key, value) {
-        try {
-          if (typeof GM_setValue === 'function') {
-            GM_setValue(key, value);
-            return;
-          }
-        } catch (error) {
-          // ignore
-        }
-        window.localStorage.setItem(key, value);
-      }
-    };
+    const storage = new StorageAdapter();
 
     // Phase 3: Initialize sync manager
     const syncManager = new SyncManager(storage);
@@ -3802,23 +3790,7 @@
       }
 
       const restoredCard = syncManager.syncClient.syncEngine.sanitizeCardForMerge(remoteCards[cardName]);
-      const nextSettings = loadSettings();
-      const targetCardSettings = ensureCardSettings(nextSettings, cardName, cardConfig);
-      targetCardSettings.selectedCategories = Array.from({ length: cardConfig.subcapSlots }, (_, index) => {
-        const value = restoredCard.selectedCategories?.[index];
-        return typeof value === 'string' ? value : '';
-      });
-      targetCardSettings.defaultCategory =
-        typeof restoredCard.defaultCategory === 'string' && restoredCard.defaultCategory
-          ? restoredCard.defaultCategory
-          : 'Others';
-      targetCardSettings.merchantMap = isObjectRecord(restoredCard.merchantMap)
-        ? { ...restoredCard.merchantMap }
-        : {};
-      targetCardSettings.monthlyTotals = isObjectRecord(restoredCard.monthlyTotals)
-        ? { ...restoredCard.monthlyTotals }
-        : {};
-      saveSettings(nextSettings);
+      applyCardSettingsToLocalStore(cardName, restoredCard);
 
       syncManager.saveBootstrapRestoreOutcome('restored', {
         markDone: true,
@@ -3832,31 +3804,36 @@
       };
     }
 
-    function applyResolvedCardSettingsToLocalStore(resolvedCardName, resolvedCardSettings) {
-      if (!resolvedCardName || !isObjectRecord(resolvedCardSettings)) {
-        return;
+    function applyCardSettingsToLocalStore(cardNameToApply, cardSettingsToApply) {
+      if (!cardNameToApply || !isObjectRecord(cardSettingsToApply)) {
+        return false;
       }
       const nextSettings = loadSettings();
-      const resolvedCardConfig = CARD_CONFIGS[resolvedCardName];
-      if (!resolvedCardConfig) {
-        return;
+      const configToApply = CARD_CONFIGS[cardNameToApply];
+      if (!configToApply) {
+        return false;
       }
-      const targetCardSettings = ensureCardSettings(nextSettings, resolvedCardName, resolvedCardConfig);
-      targetCardSettings.selectedCategories = Array.from({ length: resolvedCardConfig.subcapSlots }, (_, index) => {
-        const value = resolvedCardSettings.selectedCategories?.[index];
+      const targetCardSettings = ensureCardSettings(nextSettings, cardNameToApply, configToApply);
+      targetCardSettings.selectedCategories = Array.from({ length: configToApply.subcapSlots }, (_, index) => {
+        const value = cardSettingsToApply.selectedCategories?.[index];
         return typeof value === 'string' ? value : '';
       });
       targetCardSettings.defaultCategory =
-        typeof resolvedCardSettings.defaultCategory === 'string' && resolvedCardSettings.defaultCategory
-          ? resolvedCardSettings.defaultCategory
+        typeof cardSettingsToApply.defaultCategory === 'string' && cardSettingsToApply.defaultCategory
+          ? cardSettingsToApply.defaultCategory
           : 'Others';
-      targetCardSettings.merchantMap = isObjectRecord(resolvedCardSettings.merchantMap)
-        ? { ...resolvedCardSettings.merchantMap }
+      targetCardSettings.merchantMap = isObjectRecord(cardSettingsToApply.merchantMap)
+        ? { ...cardSettingsToApply.merchantMap }
         : {};
-      targetCardSettings.monthlyTotals = isObjectRecord(resolvedCardSettings.monthlyTotals)
-        ? { ...resolvedCardSettings.monthlyTotals }
+      targetCardSettings.monthlyTotals = isObjectRecord(cardSettingsToApply.monthlyTotals)
+        ? { ...cardSettingsToApply.monthlyTotals }
         : {};
       saveSettings(nextSettings);
+      return true;
+    }
+
+    function applyResolvedCardSettingsToLocalStore(resolvedCardName, resolvedCardSettings) {
+      applyCardSettingsToLocalStore(resolvedCardName, resolvedCardSettings);
     }
 
     function removeUI(options = {}) {
@@ -5163,54 +5140,11 @@
     }
 
     function formatMonthLabel(monthKey) {
-      const match = String(monthKey).match(/^(\d{4})-(\d{2})$/);
-      if (!match) {
-        return monthKey;
-      }
-      const year = match[1];
-      const monthIndex = Number(match[2]) - 1;
-      const monthNames = [
-        'Jan',
-        'Feb',
-        'Mar',
-        'Apr',
-        'May',
-        'Jun',
-        'Jul',
-        'Aug',
-        'Sep',
-        'Oct',
-        'Nov',
-        'Dec'
-      ];
-      if (!monthNames[monthIndex]) {
-        return monthKey;
-      }
-      return `${monthNames[monthIndex]} ${year}`;
+      return formatMonthKeyForDisplay(monthKey, monthKey);
     }
 
     function calculateMonthlyTotals(transactions, cardSettings) {
-      const totalsByMonth = {};
-
-      transactions.forEach((transaction) => {
-        if (!transaction.posting_month) {
-          return;
-        }
-        if (typeof transaction.amount_value !== 'number') {
-          return;
-        }
-        const monthKey = transaction.posting_month;
-        if (!totalsByMonth[monthKey]) {
-          totalsByMonth[monthKey] = { totals: {}, total_amount: 0 };
-        }
-        const category =
-          transaction.category || cardSettings.defaultCategory || 'Others';
-        totalsByMonth[monthKey].totals[category] =
-          (totalsByMonth[monthKey].totals[category] || 0) + transaction.amount_value;
-        totalsByMonth[monthKey].total_amount += transaction.amount_value;
-      });
-
-      return totalsByMonth;
+      return calculateMonthlyTotalsForSync(transactions, cardSettings);
     }
 
     function setButtonState(options = {}) {
@@ -5943,13 +5877,14 @@
 
       const transactionsByMonth = {};
       storedTransactions.forEach((tx) => {
-        if (!tx.posting_month) {
+        const monthKey = getTransactionMonthKey(tx);
+        if (!monthKey || typeof tx.amount_value !== 'number' || !Number.isFinite(tx.amount_value)) {
           return;
         }
-        if (!transactionsByMonth[tx.posting_month]) {
-          transactionsByMonth[tx.posting_month] = [];
+        if (!transactionsByMonth[monthKey]) {
+          transactionsByMonth[monthKey] = [];
         }
-        transactionsByMonth[tx.posting_month].push(tx);
+        transactionsByMonth[monthKey].push(tx);
       });
 
       if (!months.length) {
@@ -5974,9 +5909,7 @@
           if (!grouped[category]) {
             grouped[category] = { total: 0, transactions: [] };
           }
-          if (typeof tx.amount_value === 'number') {
-            grouped[category].total += tx.amount_value;
-          }
+          grouped[category].total += tx.amount_value;
           grouped[category].transactions.push(tx);
         });
 
@@ -6688,6 +6621,7 @@
         loadSettings,
         saveSettings,
         ensureCardSettings,
+        applyCardSettingsToLocalStore,
         updateStoredTransactions,
         buildFallbackData,
         getStoredTransactions,


### PR DESCRIPTION
## Summary
- Harden backend payload-size handling, refresh-token rotation races, and logout blacklist semantics.
- Require HTTPS for userscript sync URLs except localhost/loopback and align Tampermonkey grants/connect metadata.
- Deduplicate userscript storage, sync card-setting apply logic, monthly totals/month labels, test doubles, and split backend web page constants/helpers.

## Verification
- npm run test:anti-patterns
- npm run test:userscript
- npm run lint:userscript
- npm --prefix apps/backend run test:quality
- npm --prefix apps/backend test