### PR TITLE
fix(sync): clarify saved unlock flow

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bank-cc/backend",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "type": "module",
   "description": "Sync backend for bank CC calculator (Cloudflare Workers + D1)",
   "main": "src/index.js",

--- a/apps/userscript/__tests__/sync-ui-overlay.test.js
+++ b/apps/userscript/__tests__/sync-ui-overlay.test.js
@@ -416,11 +416,14 @@ describe('sync ui + overlay', () => {
     const doc = makeDocument();
     globalThis.document = doc;
     globalThis.window = { setTimeout: () => 0, clearTimeout: () => {} };
+    const timers = createFakeTimers();
+    timers.bindToWindow(globalThis.window);
 
     let cacheUnlockResolve;
     let syncResolve;
     let unlocked = false;
     let syncCalls = 0;
+    let refreshCalls = 0;
     const manager = {
       config: { email: 'user@example.com', lastSync: 0, tier: 'free', rememberUnlock: true },
       isEnabled: () => true,
@@ -434,7 +437,7 @@ describe('sync ui + overlay', () => {
       disableSync: () => {}
     };
 
-    const container = exports.createSyncTab(manager, 'XL Rewards Card', {}, [], makeTheme(), () => {});
+    const container = exports.createSyncTab(manager, 'XL Rewards Card', {}, [], makeTheme(), () => { refreshCalls += 1; });
     const syncNowButton = container.querySelector('#sync-now-btn');
     const status = container.querySelector('#sync-status');
 
@@ -448,10 +451,17 @@ describe('sync ui + overlay', () => {
     await Promise.resolve();
     assert.equal(syncCalls, 1);
     assert.equal(status.textContent, 'Saved unlock restored. Syncing active card...');
+    timers.advanceBy(0);
+    assert.equal(refreshCalls, 0, 'saved unlock should not refresh/rerender before sync completes');
 
     syncResolve({ success: true });
     await clickPromise;
     assert.equal(status.textContent, 'Synced successfully.');
+    timers.advanceBy(799);
+    assert.equal(refreshCalls, 0, 'successful sync refresh should remain delayed');
+    timers.advanceBy(1);
+    assert.equal(refreshCalls, 1, 'successful sync should refresh after the success status is visible');
+    timers.unbindFromWindow();
   });
 
   it('createSyncTab asks for password when saved unlock fails from Sync Now', async () => {

--- a/apps/userscript/__tests__/sync-ui-overlay.test.js
+++ b/apps/userscript/__tests__/sync-ui-overlay.test.js
@@ -280,7 +280,7 @@ describe('sync ui + overlay', () => {
         cardName: 'XL Rewards Card',
         expected: {
           badge: 'Sync locked',
-          detail: 'Last sync: Never. Open the Sync tab to unlock before pushing changes.',
+          detail: 'Last sync: Never. Password is required to unlock sync before pushing changes.',
           tabLabel: 'Sync • Locked'
         }
       },
@@ -296,7 +296,7 @@ describe('sync ui + overlay', () => {
         cardName: 'XL Rewards Card',
         expected: {
           badge: 'Sync locked (auto unlock available)',
-          detail: 'Last sync: Never. Open the Sync tab to unlock before pushing changes.',
+          detail: 'Last sync: Never. Saved unlock is available; Sync Now will try it automatically.',
           tabLabel: 'Sync • Auto unlock'
         }
       },
@@ -410,6 +410,100 @@ describe('sync ui + overlay', () => {
     await disableButton.click();
     assert.equal(disabled, true);
     timers.unbindFromWindow();
+  });
+
+  it('createSyncTab tries saved unlock before syncing from Sync Now', async () => {
+    const doc = makeDocument();
+    globalThis.document = doc;
+    globalThis.window = { setTimeout: () => 0, clearTimeout: () => {} };
+
+    let cacheUnlockResolve;
+    let syncResolve;
+    let unlocked = false;
+    let syncCalls = 0;
+    const manager = {
+      config: { email: 'user@example.com', lastSync: 0, tier: 'free', rememberUnlock: true },
+      isEnabled: () => true,
+      isUnlocked: () => unlocked,
+      hasRememberedUnlockCache: () => true,
+      tryUnlockFromRememberedCache: async () => new Promise((resolve) => { cacheUnlockResolve = resolve; }),
+      sync: async () => {
+        syncCalls += 1;
+        return new Promise((resolve) => { syncResolve = resolve; });
+      },
+      disableSync: () => {}
+    };
+
+    const container = exports.createSyncTab(manager, 'XL Rewards Card', {}, [], makeTheme(), () => {});
+    const syncNowButton = container.querySelector('#sync-now-btn');
+    const status = container.querySelector('#sync-status');
+
+    const clickPromise = syncNowButton.click();
+    await Promise.resolve();
+    assert.equal(status.textContent, 'Trying saved unlock...');
+
+    unlocked = true;
+    cacheUnlockResolve(true);
+    await Promise.resolve();
+    await Promise.resolve();
+    assert.equal(syncCalls, 1);
+    assert.equal(status.textContent, 'Saved unlock restored. Syncing active card...');
+
+    syncResolve({ success: true });
+    await clickPromise;
+    assert.equal(status.textContent, 'Synced successfully.');
+  });
+
+  it('createSyncTab asks for password when saved unlock fails from Sync Now', async () => {
+    const doc = makeDocument();
+    globalThis.document = doc;
+    globalThis.window = { setTimeout: () => 0, clearTimeout: () => {} };
+
+    const manager = {
+      config: { email: 'user@example.com', lastSync: 0, tier: 'free', rememberUnlock: true },
+      isEnabled: () => true,
+      isUnlocked: () => false,
+      hasRememberedUnlockCache: () => true,
+      tryUnlockFromRememberedCache: async () => false,
+      sync: async () => ({ success: true }),
+      disableSync: () => {}
+    };
+
+    const container = exports.createSyncTab(manager, 'XL Rewards Card', {}, [], makeTheme(), () => {});
+    const syncNowButton = container.querySelector('#sync-now-btn');
+    const status = container.querySelector('#sync-status');
+
+    assert.match(container.innerHTML, /Saved unlock is available\. Sync Now will try it automatically/);
+    await syncNowButton.click();
+
+    assert.equal(status.textContent, "Saved unlock couldn't be used. Enter your password to unlock sync.");
+  });
+
+  it('createSyncTab says password is required when Sync Now is locked without saved unlock', async () => {
+    const doc = makeDocument();
+    globalThis.document = doc;
+    globalThis.window = { setTimeout: () => 0, clearTimeout: () => {} };
+
+    let cacheUnlockCalls = 0;
+    const manager = {
+      config: { email: 'user@example.com', lastSync: 0, tier: 'free', rememberUnlock: false },
+      isEnabled: () => true,
+      isUnlocked: () => false,
+      hasRememberedUnlockCache: () => false,
+      tryUnlockFromRememberedCache: async () => { cacheUnlockCalls += 1; return false; },
+      sync: async () => ({ success: true }),
+      disableSync: () => {}
+    };
+
+    const container = exports.createSyncTab(manager, 'XL Rewards Card', {}, [], makeTheme(), () => {});
+    const syncNowButton = container.querySelector('#sync-now-btn');
+    const status = container.querySelector('#sync-status');
+
+    assert.match(container.innerHTML, /Password is required to unlock sync before syncing this card/);
+    await syncNowButton.click();
+
+    assert.equal(cacheUnlockCalls, 0);
+    assert.equal(status.textContent, 'Sync is locked. Password is required to unlock sync.');
   });
 
   it('createSyncTab dismisses bootstrap status after successful sync', async () => {

--- a/apps/userscript/bank-cc-limits-subcap-calculator.user.js
+++ b/apps/userscript/bank-cc-limits-subcap-calculator.user.js
@@ -2602,7 +2602,9 @@
 
     return {
       badge: hasRememberedUnlock ? 'Sync locked (auto unlock available)' : 'Sync locked',
-      detail: `Last sync: ${lastSyncText}. Open the Sync tab to unlock before pushing changes.`,
+      detail: hasRememberedUnlock
+        ? `Last sync: ${lastSyncText}. Saved unlock is available; Sync Now will try it automatically.`
+        : `Last sync: ${lastSyncText}. Password is required to unlock sync before pushing changes.`,
       variant: 'info',
       tabLabel: hasRememberedUnlock ? 'Sync • Auto unlock' : 'Sync • Locked'
     };
@@ -2870,6 +2872,11 @@
     const lockStateText = isUnlocked
       ? 'Unlocked'
       : (hasRememberedUnlock ? 'Locked (auto unlock available)' : 'Locked (password required)');
+    const lockHelperText = isUnlocked
+      ? 'Sync is unlocked for this session.'
+      : (hasRememberedUnlock
+          ? 'Saved unlock is available. Sync Now will try it automatically before asking for your password.'
+          : 'Password is required to unlock sync before syncing this card.');
     const rememberChecked = config.rememberUnlock === true || hasRememberedUnlock;
 
     container.innerHTML = `
@@ -2881,6 +2888,7 @@
         <p class="${UI_CLASSES.meta}"><strong>Last Sync:</strong> ${escapeHtml(lastSync)}</p>
         <p class="${UI_CLASSES.meta}"><strong>Tier:</strong> ${escapeHtml(config.tier || '-')}</p>
         ${bootstrapStatus ? `<p id="sync-bootstrap-status-row" class="${UI_CLASSES.meta}"><strong>Last bootstrap result:</strong> ${escapeHtml(bootstrapStatus)}${bootstrapStatusAt ? ` (${escapeHtml(bootstrapStatusAt)})` : ''}</p>` : ''}
+        <p class="${UI_CLASSES.small}">${escapeHtml(lockHelperText)}</p>
         <p class="${UI_CLASSES.small}">Sync only pushes the active card from this page. Other remote card keys stay intact.</p>
       </div>
       ${pendingConflict ? `
@@ -3047,8 +3055,15 @@
         }
 
         if (!syncManager.isUnlocked()) {
-          const unlockedFromCache = await syncManager.tryUnlockFromRememberedCache();
+          const hasRememberedUnlockNow = typeof syncManager.hasRememberedUnlockCache === 'function'
+            && syncManager.hasRememberedUnlockCache();
+          let unlockedFromCache = false;
+          if (hasRememberedUnlockNow) {
+            setStatusMessage(statusDiv, 'Trying saved unlock...', 'info');
+            unlockedFromCache = await syncManager.tryUnlockFromRememberedCache();
+          }
           if (unlockedFromCache) {
+            setStatusMessage(statusDiv, 'Saved unlock restored. Syncing active card...', 'info');
             window.setTimeout(() => onSyncStateChanged(), 0);
           }
 
@@ -3056,7 +3071,13 @@
           const passphrase = passphraseInput?.value || '';
 
           if (!syncManager.isUnlocked() && !passphrase) {
-            setStatusMessage(statusDiv, 'Sync is locked. Enter your password to unlock first.', 'warning');
+            setStatusMessage(
+              statusDiv,
+              hasRememberedUnlockNow
+                ? "Saved unlock couldn't be used. Enter your password to unlock sync."
+                : 'Sync is locked. Password is required to unlock sync.',
+              'warning'
+            );
             return;
           }
 

--- a/apps/userscript/bank-cc-limits-subcap-calculator.user.js
+++ b/apps/userscript/bank-cc-limits-subcap-calculator.user.js
@@ -3064,7 +3064,6 @@
           }
           if (unlockedFromCache) {
             setStatusMessage(statusDiv, 'Saved unlock restored. Syncing active card...', 'info');
-            window.setTimeout(() => onSyncStateChanged(), 0);
           }
 
           const passphraseInput = container.querySelector('#sync-unlock-passphrase');

--- a/apps/userscript/bank-cc-limits-subcap-calculator.user.js
+++ b/apps/userscript/bank-cc-limits-subcap-calculator.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Bank CC Limits Subcap Calculator
 // @namespace    local
-// @version      1.1.1
+// @version      1.1.2
 // @description  Extract credit card transactions and manage subcap categories with optional sync
 // @author       laurenceputra
 // @downloadURL  https://raw.githubusercontent.com/laurenceputra/sg-cc-mile-subcaps-limits-viewer/main/apps/userscript/bank-cc-limits-subcap-calculator.user.js

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bank-cc-subcap-calculator",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bank-cc-subcap-calculator",
-      "version": "1.1.1",
+      "version": "1.1.2",
       "license": "MIT",
       "workspaces": [
         "apps/backend"
@@ -17,7 +17,7 @@
     },
     "apps/backend": {
       "name": "@bank-cc/backend",
-      "version": "1.1.1",
+      "version": "1.1.2",
       "license": "MIT",
       "dependencies": {
         "hono": "^4.0.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bank-cc-subcap-calculator",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "private": true,
   "type": "module",
   "description": "Credit card subcap calculator with optional sync",


### PR DESCRIPTION
## Summary
- clarify locked sync messaging when saved unlock is or is not available
- show explicit Sync Now status while trying saved unlock and after it restores
- fall back to clearer password-required messaging when saved unlock is unavailable or cannot be used
- add UI tests for saved unlock success/failure and no-cache locked flows

## Verification
- node --test apps/userscript/__tests__/sync-ui-overlay.test.js
- node --test apps/userscript/__tests__/*.test.js
- npm run test:anti-patterns
- git diff --check

## Note
- npm run lint:userscript could not run in this environment because eslint is not installed (sh: 1: eslint: not found).